### PR TITLE
fix: use msat value for min and max

### DIFF
--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -34,8 +34,8 @@ export const parseLnUrlPayResponse = (
 
   const callback = (data.callback + '').trim();
 
-  const min = Math.ceil(Number(data.minSendable || 0) / 1000)
-  const max = Math.floor(Number(data.maxSendable) / 1000)
+  const min = Math.ceil(Number(data.minSendable || 0))
+  const max = Math.floor(Number(data.maxSendable))
   if (!(min && max) || min > max) throw new Error('Invalid pay service params')
 
   let metadata: Array<Array<string>>


### PR DESCRIPTION
fixes isValidAmount checking a msat amount against a sat min/max value