### PR TITLE
fix(402): fall through unknown payment methods to lightning offers

### DIFF
--- a/src/402/fetch402.test.ts
+++ b/src/402/fetch402.test.ts
@@ -1,0 +1,164 @@
+import fetchMock from "jest-fetch-mock";
+import { fetch402 } from "./fetch402";
+import {
+  encodeMppChargeRequest,
+  makeMppWwwAuthenticateHeader,
+} from "./mpp/utils";
+
+const INVOICE =
+  "lnbc4020n1p5m6028dq80q6rqvsnp4qt5w34u6kntf5lc50jj27rvs89sgrpcpj7s6vfts042gkhxx2j6swpp5g6tquvmswkv5xf0ru7ju2qvdrf83l2ewha3qzzt0a7vurs5q30rssp54kt5hfzjngjersx8fgt60feuu8e7vnat67f3ksr98twdj7z0m0ls9qyysgqcqzp2xqyz5vqrzjqdc22wfv6lyplagj37n9dmndkrzdz8rh3lxkewvvk6arkjpefats2rf47yqqwysqqcqqqqlgqqqqqqgqfqrzjq26922n6s5n5undqrf78rjjhgpcczafws45tx8237y7pzx3fg8ww8apyqqqqqqqqjyqqqqlgqqqqr4gq2q3z5pu33awfm98ac3ysdhy046xmen4zqval67tccu35x9mxgvl6w3wmq6y03ae7pme6qr20mp5gvuqntnu8yy7nlf6gyt9zshanj2zhgqe4xde3";
+const PREIMAGE =
+  "8196e90022ce688d911554d02af67d3d6a72143961c1e1aa12c4720538ea0549";
+
+const URL = "https://example.com/protected";
+
+const LIGHTNING_REQUIREMENTS = {
+  scheme: "exact",
+  network: "bip122:000000000019d6689c085ae165831e93",
+  amount: "402000",
+  asset: "BTC",
+  payTo: "anonymous",
+  extra: { paymentMethod: "lightning", invoice: INVOICE },
+};
+
+const USDC_REQUIREMENTS = {
+  scheme: "exact",
+  network: "eip155:8453",
+  amount: "100000",
+  asset: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+  payTo: "0xd5f8481D8F25d3966d2010DBf9B47fFbdf745A9E",
+  extra: { name: "USD Coin", version: "2" },
+};
+
+function paymentRequiredHeader(accepts: unknown[]): string {
+  return btoa(unescape(encodeURIComponent(JSON.stringify({ accepts }))));
+}
+
+function makeWallet(preimage: string = PREIMAGE) {
+  return { payInvoice: jest.fn().mockResolvedValue({ preimage }) };
+}
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+});
+
+describe("fetch402 dispatcher", () => {
+  test("pays lightning offer in PAYMENT-REQUIRED with mixed USDC + lightning accepts", async () => {
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": paymentRequiredHeader([
+          USDC_REQUIREMENTS,
+          LIGHTNING_REQUIREMENTS,
+        ]),
+      },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ paid: true }), { status: 200 });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).toHaveBeenCalledWith({ invoice: INVOICE });
+    expect(response.status).toBe(200);
+  });
+
+  test("falls through unknown WWW-Authenticate Payment method to x402 lightning offer", async () => {
+    // Asterpay-style: Payment method="asterpay" alongside x402 PAYMENT-REQUIRED
+    // with both USDC and lightning entries. We don't speak `method=asterpay`,
+    // so we must fall through to x402 and pay the lightning entry.
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "WWW-Authenticate":
+          'Payment id="abc", realm="example.com", method="asterpay", intent="charge", request="eyJhIjoxfQ"',
+        "PAYMENT-REQUIRED": paymentRequiredHeader([
+          USDC_REQUIREMENTS,
+          LIGHTNING_REQUIREMENTS,
+        ]),
+      },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ paid: true }), { status: 200 });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).toHaveBeenCalledWith({ invoice: INVOICE });
+    expect(response.status).toBe(200);
+  });
+
+  test("returns original 402 when no payable lightning offer is present", async () => {
+    // USDC-only endpoint: a non-lightning wallet would handle this. We pass
+    // the original 402 back to the caller so they can act on it themselves.
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": paymentRequiredHeader([USDC_REQUIREMENTS]),
+      },
+    });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(response.status).toBe(402);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns original 402 when only an unknown WWW-Authenticate Payment method is present", async () => {
+    // Pure MPP-USDC challenge with no lightning fallback: dispatcher must
+    // pass the response through, not throw "unsupported scheme".
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "WWW-Authenticate":
+          'Payment id="abc", realm="example.com", method="asterpay", intent="charge", request="eyJhIjoxfQ"',
+      },
+    });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(response.status).toBe(402);
+  });
+
+  test("pays MPP-lightning challenge when method=lightning intent=charge", async () => {
+    const wallet = makeWallet();
+
+    const wwwAuth = makeMppWwwAuthenticateHeader({
+      id: "id123",
+      realm: "example.com",
+      request: encodeMppChargeRequest({
+        amount: "10",
+        currency: "sat",
+        methodDetails: { invoice: INVOICE },
+      }),
+    });
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: { "WWW-Authenticate": wwwAuth },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ paid: true }), { status: 200 });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).toHaveBeenCalledWith({ invoice: INVOICE });
+    expect(response.status).toBe(200);
+  });
+
+  test("returns 200 unchanged when there is no 402", async () => {
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce(JSON.stringify({ free: true }), { status: 200 });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/402/fetch402.test.ts
+++ b/src/402/fetch402.test.ts
@@ -64,16 +64,16 @@ describe("fetch402 dispatcher", () => {
   });
 
   test("falls through unknown WWW-Authenticate Payment method to x402 lightning offer", async () => {
-    // Asterpay-style: Payment method="asterpay" alongside x402 PAYMENT-REQUIRED
-    // with both USDC and lightning entries. We don't speak `method=asterpay`,
-    // so we must fall through to x402 and pay the lightning entry.
+    // An unknown WWW-Authenticate Payment method alongside x402 PAYMENT-REQUIRED
+    // with both USDC and lightning entries. We don't speak `method=unknown`, so
+    // we must fall through to x402 and pay the lightning entry.
     const wallet = makeWallet();
 
     fetchMock.mockResponseOnce("Payment Required", {
       status: 402,
       headers: {
         "WWW-Authenticate":
-          'Payment id="abc", realm="example.com", method="asterpay", intent="charge", request="eyJhIjoxfQ"',
+          'Payment id="abc", realm="example.com", method="unknown", intent="charge", request="eyJhIjoxfQ"',
         "PAYMENT-REQUIRED": paymentRequiredHeader([
           USDC_REQUIREMENTS,
           LIGHTNING_REQUIREMENTS,
@@ -116,7 +116,7 @@ describe("fetch402 dispatcher", () => {
       status: 402,
       headers: {
         "WWW-Authenticate":
-          'Payment id="abc", realm="example.com", method="asterpay", intent="charge", request="eyJhIjoxfQ"',
+          'Payment id="abc", realm="example.com", method="unknown", intent="charge", request="eyJhIjoxfQ"',
       },
     });
 

--- a/src/402/fetch402.test.ts
+++ b/src/402/fetch402.test.ts
@@ -126,6 +126,25 @@ describe("fetch402 dispatcher", () => {
     expect(response.status).toBe(402);
   });
 
+  test("returns original 402 when PAYMENT-REQUIRED accepts contains a malformed entry", async () => {
+    // Malformed accepts entry (e.g., null) must not throw — the dispatcher
+    // probes for a payable lightning offer and falls through when none is found.
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": paymentRequiredHeader([null]),
+      },
+    });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(response.status).toBe(402);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test("pays MPP-lightning challenge when method=lightning intent=charge", async () => {
     const wallet = makeWallet();
 

--- a/src/402/fetch402.ts
+++ b/src/402/fetch402.ts
@@ -1,7 +1,8 @@
 import { Wallet, createGuardedWallet } from "./utils";
 import { handleL402Payment } from "./l402/l402";
-import { handleX402Payment } from "./x402/x402";
+import { findX402LightningRequirements, handleX402Payment } from "./x402/x402";
 import { handleMppChargePayment } from "./mpp/mpp";
+import { parseMppChallenge } from "./mpp/utils";
 
 export const fetch402 = async (
   url: string,
@@ -24,28 +25,37 @@ export const fetch402 = async (
 
   const initResp = await fetch(url, fetchArgs);
 
+  // L402 / LSAT: dedicated scheme, dispatch directly.
   const wwwAuthHeader = initResp.headers.get("www-authenticate");
   if (wwwAuthHeader) {
     const trimmed = wwwAuthHeader.trimStart().toLowerCase();
-    if (trimmed.startsWith("payment")) {
-      return handleMppChargePayment(
-        wwwAuthHeader,
-        url,
-        fetchArgs,
-        headers,
-        wallet,
-      );
-    }
     if (trimmed.startsWith("l402") || trimmed.startsWith("lsat")) {
       return handleL402Payment(wwwAuthHeader, url, fetchArgs, headers, wallet);
     }
-    throw new Error(
-      `fetch402: unsupported WWW-Authenticate scheme: ${wwwAuthHeader}`,
+  }
+
+  // A server may advertise multiple payment options at once (e.g. an MPP
+  // USDC challenge in WWW-Authenticate alongside an x402 PAYMENT-REQUIRED
+  // header that lists both USDC and lightning). Try each lightning-payable
+  // handler in turn; only if none matches do we hand the original 402 back
+  // to the caller so they can decide what to do with non-lightning offers.
+
+  // 1. MPP-lightning challenge (Payment method="lightning" intent="charge").
+  //    parseMppChallenge returns null for any other method, which lets us
+  //    fall through to x402 instead of throwing.
+  if (wwwAuthHeader && parseMppChallenge(wwwAuthHeader)) {
+    return handleMppChargePayment(
+      wwwAuthHeader,
+      url,
+      fetchArgs,
+      headers,
+      wallet,
     );
   }
 
+  // 2. x402 PAYMENT-REQUIRED with a lightning entry in `accepts`.
   const x402Header = initResp.headers.get("PAYMENT-REQUIRED");
-  if (x402Header) {
+  if (x402Header && findX402LightningRequirements(x402Header)) {
     return handleX402Payment(x402Header, url, fetchArgs, headers, wallet);
   }
 

--- a/src/402/x402/index.ts
+++ b/src/402/x402/index.ts
@@ -1,1 +1,1 @@
-export { fetchWithX402 } from "./x402";
+export { fetchWithX402, findX402LightningRequirements } from "./x402";

--- a/src/402/x402/x402.ts
+++ b/src/402/x402/x402.ts
@@ -2,13 +2,9 @@ import { Wallet } from "../utils";
 import { buildX402PaymentSignature, X402Requirements } from "./utils";
 import { Invoice } from "../../bolt11";
 
-export const handleX402Payment = async (
+const decodeX402Header = (
   x402Header: string,
-  url: string,
-  fetchArgs: RequestInit,
-  headers: Headers,
-  wallet: Wallet,
-): Promise<Response> => {
+): { accepts: X402Requirements[] } => {
   let parsed: { accepts?: unknown[] };
   try {
     parsed = JSON.parse(decodeURIComponent(escape(atob(x402Header))));
@@ -23,10 +19,44 @@ export const handleX402Payment = async (
       "x402: PAYMENT-REQUIRED header contains no payment options",
     );
   }
+  return { accepts: parsed.accepts as X402Requirements[] };
+};
 
-  const requirements = (parsed.accepts as X402Requirements[]).find((e) => {
-    return e.extra?.paymentMethod === "lightning";
-  });
+/**
+ * Probe a PAYMENT-REQUIRED header for a lightning-payable offer without
+ * throwing. Returns the matching requirements, or null if the header has no
+ * lightning entry (e.g. USDC-only endpoints) or is malformed. Used by the
+ * top-level fetch402 dispatcher to decide whether to attempt payment or hand
+ * the 402 back to the caller.
+ */
+export const findX402LightningRequirements = (
+  x402Header: string,
+): X402Requirements | null => {
+  let accepts: X402Requirements[];
+  try {
+    ({ accepts } = decodeX402Header(x402Header));
+  } catch (_) {
+    return null;
+  }
+  const requirements = accepts.find(
+    (e) => e.extra?.paymentMethod === "lightning",
+  );
+  if (!requirements?.extra?.invoice) return null;
+  return requirements;
+};
+
+export const handleX402Payment = async (
+  x402Header: string,
+  url: string,
+  fetchArgs: RequestInit,
+  headers: Headers,
+  wallet: Wallet,
+): Promise<Response> => {
+  const { accepts } = decodeX402Header(x402Header);
+
+  const requirements = accepts.find(
+    (e) => e.extra?.paymentMethod === "lightning",
+  );
   if (!requirements) {
     throw new Error(
       "x402: unsupported x402 network, only Bitcoin lightning network is supported.",

--- a/src/402/x402/x402.ts
+++ b/src/402/x402/x402.ts
@@ -39,7 +39,7 @@ export const findX402LightningRequirements = (
     return null;
   }
   const requirements = accepts.find(
-    (e) => e.extra?.paymentMethod === "lightning",
+    (e) => e?.extra?.paymentMethod === "lightning",
   );
   if (!requirements?.extra?.invoice) return null;
   return requirements;
@@ -55,7 +55,7 @@ export const handleX402Payment = async (
   const { accepts } = decodeX402Header(x402Header);
 
   const requirements = accepts.find(
-    (e) => e.extra?.paymentMethod === "lightning",
+    (e) => e?.extra?.paymentMethod === "lightning",
   );
   if (!requirements) {
     throw new Error(


### PR DESCRIPTION
## Summary

The `fetch402` dispatcher routed any `WWW-Authenticate: Payment` header straight to the MPP handler, which throws on methods other than `lightning`. A server that advertises an MPP-USDC challenge alongside an x402 `PAYMENT-REQUIRED` header therefore fails before the lightning entry in `accepts` is ever considered.

Make dispatch additive: try each lightning-payable handler in turn and hand the original 402 back to the caller if none matches. This also unblocks USDC-only x402 endpoints — the dispatcher now returns the 402 to the caller instead of throwing `"unsupported WWW-Authenticate scheme"`.

The dedicated helpers (`fetchWithMpp`, `fetchWithX402`) keep their existing throw semantics; only the auto-detect entry point is relaxed.

## Changes

- `fetch402.ts`: dispatch order is now L402 → MPP-lightning (only if `parseMppChallenge` validates) → x402 (only if a lightning offer is in `accepts`) → return original 402.
- `x402.ts`: extracted `findX402LightningRequirements` as a non-throwing probe used by the dispatcher to decide whether to attempt payment; guarded against malformed `accepts` entries.
- `fetch402.test.ts`: 7 tests covering mixed offers, unknown-method fall-through, USDC-only pass-through, malformed `accepts`, MPP-lightning happy path, and unchanged 200 responses.

## Test plan

- [x] `yarn test` — all tests pass (7 new dispatcher tests + existing suites unchanged)
- [x] `yarn lint` — clean
- [x] Manual e2e against a mixed MPP-USDC + x402-lightning endpoint via Hub flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)