### PR TITLE
feat: add BIP21 (bitcoin: URI) parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,7 @@ const nwc = new NWCClient({
   nostrWalletConnectUrl: "nostr+walletconnect://...",
 });
 
-await fetch402(
-  "https://example.com/protected-resource",
-  {},
-  { wallet: nwc },
-)
+await fetch402("https://example.com/protected-resource", {}, { wallet: nwc })
   .then((res) => res.json())
   .then(console.log)
   .finally(() => nwc.close());
@@ -244,9 +240,9 @@ await fetchWithL402(
 #### X402
 
 Similar to L402 X402 is an open protocol for machine-to-machine payments built on the HTTP 402 Payment Required status code.
-It enables APIs and resources to request payments inline, without prior registration or authentication. 
+It enables APIs and resources to request payments inline, without prior registration or authentication.
 
-This library includes a `fetchWithX402` function to consume X402-protected resources that support the lightning network. 
+This library includes a `fetchWithX402` function to consume X402-protected resources that support the lightning network.
 (Note: X402 works also with other coins and network. This library supports X402 resources that accept Bitcoin on the lightning network)
 
 ##### fetchWithX402(url: string, fetchArgs, options)
@@ -281,7 +277,7 @@ await fetchWithX402(
 MPP is an open protocol for machine-to-machine payments built on the HTTP 402 Payment Required status code.
 Charge for API requests, tool calls, or content—agents and apps pay per request in the same HTTP call.
 
-This library includes a `fetchWithMpp` function to consume MPP-protected resources that support the lightning network. 
+This library includes a `fetchWithMpp` function to consume MPP-protected resources that support the lightning network.
 (Note: MPP works also with other payment methods. This library supports resources that accept Bitcoin on the lightning network)
 
 ##### fetchWithMpp(url: string, fetchArgs, options)
@@ -356,6 +352,30 @@ await fiat.getFormattedFiatValue({
   locale: "en",
 });
 ```
+
+### BIP21 (`bitcoin:` URIs)
+
+Parse [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki) payment URIs, including the unified-QR `lightning=` fallback parameter.
+
+```js
+import { parseBip21 } from "@getalby/lightning-tools";
+
+const result = parseBip21(
+  "bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4?amount=0.001&label=Donation&lightning=lnbc...",
+);
+
+if (result) {
+  result.address; // "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+  result.amount; // 0.001 (BTC)
+  result.amountSats; // 100000
+  result.label; // "Donation"
+  result.lightning; // BOLT11 fallback, if present
+  result.lno; // BOLT12 offer, if present
+  result.unknownRequiredParams; // reject the URI if non-empty (BIP21 `req-*` rule)
+}
+```
+
+`parseBip21` returns `null` for inputs that don't start with the `bitcoin:` scheme. Address validation is intentionally out of scope — validate the returned `address` with your own check if needed.
 
 ### 🤖 Lightning Address Proxy
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
       "import": "./dist/esm/podcasting2.js",
       "require": "./dist/cjs/podcasting2.cjs",
       "types": "./dist/types/podcasting2.d.ts"
+    },
+    "./bip21": {
+      "import": "./dist/esm/bip21.js",
+      "require": "./dist/cjs/bip21.cjs",
+      "types": "./dist/types/bip21.d.ts"
     }
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,6 +25,7 @@ const entries = [
   { name: "402/mpp", input: "src/402/mpp/index.ts" },
   { name: "lnurl", input: "src/lnurl/index.ts" },
   { name: "podcasting2", input: "src/podcasting2/index.ts" },
+  { name: "bip21", input: "src/bip21/index.ts" },
 ];
 
 const subBundles = entries.flatMap(({ name, input }) => [

--- a/src/bip21/index.ts
+++ b/src/bip21/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./utils";

--- a/src/bip21/types.ts
+++ b/src/bip21/types.ts
@@ -1,0 +1,23 @@
+export type Bip21 = {
+  /** Bare on-chain bitcoin address (no scheme, no query string). */
+  address: string;
+  /** Requested amount in BTC, as defined by BIP21 (e.g. 0.01). */
+  amount?: number;
+  /** Requested amount converted to satoshis, for convenience. */
+  amountSats?: number;
+  /** Label for the recipient, decoded. */
+  label?: string;
+  /** Free-form message, decoded. */
+  message?: string;
+  /** BOLT11 invoice or LNURL, from the `lightning=` parameter (unified QR). */
+  lightning?: string;
+  /** BOLT12 offer, from the `lno=` parameter. */
+  lno?: string;
+  /**
+   * `req-*` parameters that the client doesn't know how to handle.
+   * Per BIP21, callers MUST reject the URI if this is non-empty.
+   */
+  unknownRequiredParams: string[];
+  /** All query parameters, decoded, for advanced/custom use. */
+  params: Record<string, string>;
+};

--- a/src/bip21/utils.test.ts
+++ b/src/bip21/utils.test.ts
@@ -77,6 +77,121 @@ describe("parseBip21", () => {
     );
     expect(result?.address).toBe("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
   });
+
+  test("trims surrounding whitespace before scheme detection", () => {
+    const result = parseBip21(
+      "  bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4  ",
+    );
+    expect(result?.address).toBe("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+  });
+
+  describe("BIP21 spec test vectors", () => {
+    // Examples drawn from https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki
+
+    test("just the address (spec example 1)", () => {
+      const result = parseBip21("bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W");
+      expect(result).toEqual({
+        address: "175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W",
+        params: {},
+        unknownRequiredParams: [],
+      });
+    });
+
+    test("address with label (spec example 2)", () => {
+      const result = parseBip21(
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?label=Luke-Jr",
+      );
+      expect(result?.address).toBe("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W");
+      expect(result?.label).toBe("Luke-Jr");
+    });
+
+    test("address with amount and label (spec example 3)", () => {
+      const result = parseBip21(
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=20.3&label=Luke-Jr",
+      );
+      expect(result?.address).toBe("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W");
+      expect(result?.amount).toBe(20.3);
+      expect(result?.amountSats).toBe(2_030_000_000);
+      expect(result?.label).toBe("Luke-Jr");
+    });
+
+    test("address with amount, label, and message (spec example 4)", () => {
+      const result = parseBip21(
+        "bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz",
+      );
+      expect(result?.address).toBe("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W");
+      expect(result?.amount).toBe(50);
+      expect(result?.amountSats).toBe(5_000_000_000);
+      expect(result?.label).toBe("Luke-Jr");
+      expect(result?.message).toBe("Donation for project xyz");
+    });
+  });
+
+  describe("strict BIP21 amount grammar", () => {
+    // Per BIP21 ABNF: amountparam = "amount=" *digit [ "." *digit ]
+    // We reject anything that isn't decimal-only.
+
+    test.each([
+      ["scientific notation", "1e-3"],
+      ["hex", "0x10"],
+      ["positive sign", "+1"],
+      ["negative", "-1"],
+      ["comma separator", "1,000"],
+      ["trailing dot", "5."],
+      ["leading dot", ".5"],
+      ["whitespace", " 1 "],
+      ["NaN", "NaN"],
+      ["Infinity", "Infinity"],
+      ["empty", ""],
+    ])("rejects %s (%s)", (_label, raw) => {
+      const result = parseBip21(
+        `bitcoin:bc1q...?amount=${encodeURIComponent(raw)}`,
+      );
+      expect(result?.amount).toBeUndefined();
+      expect(result?.amountSats).toBeUndefined();
+    });
+  });
+
+  describe("exact decimal -> sats conversion", () => {
+    test("integer BTC", () => {
+      expect(parseBip21("bitcoin:bc1q...?amount=1")?.amountSats).toBe(
+        100_000_000,
+      );
+      expect(parseBip21("bitcoin:bc1q...?amount=21000000")?.amountSats).toBe(
+        2_100_000_000_000_000,
+      );
+    });
+
+    test("one satoshi", () => {
+      expect(parseBip21("bitcoin:bc1q...?amount=0.00000001")?.amountSats).toBe(
+        1,
+      );
+    });
+
+    test("avoids float imprecision (0.1 + 0.2 case)", () => {
+      // 0.3 BTC in floats is 0.30000000000000004 — exact arithmetic must give 30_000_000 sats.
+      expect(parseBip21("bitcoin:bc1q...?amount=0.3")?.amountSats).toBe(
+        30_000_000,
+      );
+    });
+
+    test("pads short fractional", () => {
+      expect(parseBip21("bitcoin:bc1q...?amount=0.1")?.amountSats).toBe(
+        10_000_000,
+      );
+    });
+
+    test("rounds >8 fractional digits half-up to nearest sat", () => {
+      // 0.000000015 BTC = 1.5 sat -> 2 sat
+      expect(parseBip21("bitcoin:bc1q...?amount=0.000000015")?.amountSats).toBe(
+        2,
+      );
+      // 0.000000014 BTC = 1.4 sat -> 1 sat
+      expect(parseBip21("bitcoin:bc1q...?amount=0.000000014")?.amountSats).toBe(
+        1,
+      );
+    });
+  });
 });
 
 describe("isBip21", () => {
@@ -84,6 +199,10 @@ describe("isBip21", () => {
     expect(isBip21("bitcoin:bc1q...")).toBe(true);
     expect(isBip21("BITCOIN:bc1q...")).toBe(true);
     expect(isBip21("Bitcoin:bc1q...?amount=1")).toBe(true);
+  });
+
+  test("matches after trimming surrounding whitespace", () => {
+    expect(isBip21("  bitcoin:bc1q...  ")).toBe(true);
   });
 
   test("rejects non-BIP21 strings", () => {

--- a/src/bip21/utils.test.ts
+++ b/src/bip21/utils.test.ts
@@ -1,0 +1,94 @@
+import { isBip21, parseBip21 } from "./utils";
+
+describe("parseBip21", () => {
+  test("returns null for non-bitcoin: input", () => {
+    expect(parseBip21("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4")).toBeNull();
+    expect(parseBip21("lightning:lnbc1u1pj...")).toBeNull();
+    expect(parseBip21("")).toBeNull();
+  });
+
+  test("parses bare bitcoin: URI", () => {
+    const result = parseBip21(
+      "bitcoin:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+    );
+    expect(result).toEqual({
+      address: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      params: {},
+      unknownRequiredParams: [],
+    });
+  });
+
+  test("is case-insensitive on the scheme and preserves address case", () => {
+    const result = parseBip21(
+      "BITCOIN:bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+    );
+    expect(result?.address).toBe("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+  });
+
+  test("parses amount and converts to sats", () => {
+    const result = parseBip21("bitcoin:bc1q...?amount=0.001");
+    expect(result?.amount).toBe(0.001);
+    expect(result?.amountSats).toBe(100_000);
+  });
+
+  test("ignores invalid amount", () => {
+    const result = parseBip21("bitcoin:bc1q...?amount=notanumber");
+    expect(result?.amount).toBeUndefined();
+    expect(result?.amountSats).toBeUndefined();
+  });
+
+  test("decodes label and message", () => {
+    const result = parseBip21(
+      "bitcoin:bc1q...?label=Luke-Jr&message=Donation%20for%20project%20xyz",
+    );
+    expect(result?.label).toBe("Luke-Jr");
+    expect(result?.message).toBe("Donation for project xyz");
+  });
+
+  test("extracts unified-QR lightning fallback", () => {
+    const result = parseBip21(
+      "bitcoin:bc1q...?lightning=lnbc1u1pj4t6w0pp54wm83znxp8xly6qzuff",
+    );
+    expect(result?.lightning).toBe("lnbc1u1pj4t6w0pp54wm83znxp8xly6qzuff");
+  });
+
+  test("extracts BOLT12 offer from lno param", () => {
+    const result = parseBip21("bitcoin:bc1q...?lno=lno1qcnq...");
+    expect(result?.lno).toBe("lno1qcnq...");
+  });
+
+  test("flags unknown req-* params", () => {
+    const result = parseBip21(
+      "bitcoin:bc1q...?req-foo=bar&amount=0.5&req-label=ok",
+    );
+    // req-label is a required marker on a known param -> still safe
+    expect(result?.unknownRequiredParams).toEqual(["req-foo"]);
+    expect(result?.amount).toBe(0.5);
+  });
+
+  test("exposes raw params for custom use", () => {
+    const result = parseBip21("bitcoin:bc1q...?custom=value&amount=0.01");
+    expect(result?.params).toEqual({ custom: "value", amount: "0.01" });
+  });
+
+  test("trims whitespace around address", () => {
+    const result = parseBip21(
+      "bitcoin:  bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4  ",
+    );
+    expect(result?.address).toBe("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4");
+  });
+});
+
+describe("isBip21", () => {
+  test("matches bitcoin: URIs case-insensitively", () => {
+    expect(isBip21("bitcoin:bc1q...")).toBe(true);
+    expect(isBip21("BITCOIN:bc1q...")).toBe(true);
+    expect(isBip21("Bitcoin:bc1q...?amount=1")).toBe(true);
+  });
+
+  test("rejects non-BIP21 strings", () => {
+    expect(isBip21("bc1q...")).toBe(false);
+    expect(isBip21("lightning:lnbc1...")).toBe(false);
+    expect(isBip21("")).toBe(false);
+  });
+});

--- a/src/bip21/utils.ts
+++ b/src/bip21/utils.ts
@@ -2,6 +2,46 @@ import type { Bip21 } from "./types";
 
 const BIP21_SCHEME = /^bitcoin:/i;
 
+// BIP21 grammar: amountparam = "amount=" *digit [ "." *digit ]
+// We require at least one digit on either side of the decimal point — this is
+// slightly stricter than the spec ABNF but matches every real-world example
+// (the spec shows "50", "50.00", "20.3"). Crucially this rejects scientific
+// notation ("1e-3"), hex ("0x10"), commas, signs, and leading "+" / "-".
+const BIP21_AMOUNT_RE = /^(\d+)(?:\.(\d+))?$/;
+
+const SATS_PER_BTC = 100_000_000n;
+const BTC_DECIMALS = 8;
+
+/**
+ * Convert a BIP21-compliant decimal BTC string to an integer number of
+ * satoshis using exact decimal arithmetic (no floats). Fractional digits
+ * beyond 8 are rounded half-up to the nearest satoshi.
+ *
+ * Assumes the input has already been validated against BIP21_AMOUNT_RE.
+ */
+const btcStringToSats = (btc: string): number => {
+  const match = BIP21_AMOUNT_RE.exec(btc);
+  if (!match) {
+    // Should be unreachable — caller pre-validates.
+    return Number.NaN;
+  }
+  const [, integerPart, rawFractional = ""] = match;
+
+  let fractionalSats: bigint;
+  if (rawFractional.length <= BTC_DECIMALS) {
+    fractionalSats = BigInt(rawFractional.padEnd(BTC_DECIMALS, "0"));
+  } else {
+    // Round half-up at the satoshi boundary.
+    const truncated = rawFractional.slice(0, BTC_DECIMALS);
+    const roundDigit = rawFractional.charCodeAt(BTC_DECIMALS) - 48;
+    fractionalSats = BigInt(truncated);
+    if (roundDigit >= 5) fractionalSats += 1n;
+  }
+
+  const totalSats = BigInt(integerPart) * SATS_PER_BTC + fractionalSats;
+  return Number(totalSats);
+};
+
 /**
  * Parse a BIP21 (`bitcoin:`) URI. Returns `null` if the input doesn't have the
  * `bitcoin:` scheme.
@@ -19,11 +59,15 @@ const BIP21_SCHEME = /^bitcoin:/i;
  * // => { address: "bc1q...", amount: 0.001, amountSats: 100000, lightning: "lnbc...", ... }
  */
 export const parseBip21 = (uri: string): Bip21 | null => {
-  if (typeof uri !== "string" || !BIP21_SCHEME.test(uri)) {
+  if (typeof uri !== "string") {
+    return null;
+  }
+  const normalized = uri.trim();
+  if (!BIP21_SCHEME.test(normalized)) {
     return null;
   }
 
-  const withoutScheme = uri.replace(BIP21_SCHEME, "");
+  const withoutScheme = normalized.replace(BIP21_SCHEME, "");
   const queryStart = withoutScheme.indexOf("?");
   const address =
     queryStart === -1 ? withoutScheme : withoutScheme.slice(0, queryStart);
@@ -61,12 +105,9 @@ export const parseBip21 = (uri: string): Bip21 | null => {
     unknownRequiredParams,
   };
 
-  if (params.amount !== undefined) {
-    const amount = Number(params.amount);
-    if (Number.isFinite(amount) && amount >= 0) {
-      result.amount = amount;
-      result.amountSats = Math.round(amount * 1e8);
-    }
+  if (params.amount !== undefined && BIP21_AMOUNT_RE.test(params.amount)) {
+    result.amount = Number(params.amount);
+    result.amountSats = btcStringToSats(params.amount);
   }
   if (params.label !== undefined) result.label = params.label;
   if (params.message !== undefined) result.message = params.message;
@@ -78,4 +119,4 @@ export const parseBip21 = (uri: string): Bip21 | null => {
 
 /** Returns true if the input starts with the `bitcoin:` URI scheme. */
 export const isBip21 = (uri: string): boolean =>
-  typeof uri === "string" && BIP21_SCHEME.test(uri);
+  typeof uri === "string" && BIP21_SCHEME.test(uri.trim());

--- a/src/bip21/utils.ts
+++ b/src/bip21/utils.ts
@@ -1,0 +1,81 @@
+import type { Bip21 } from "./types";
+
+const BIP21_SCHEME = /^bitcoin:/i;
+
+/**
+ * Parse a BIP21 (`bitcoin:`) URI. Returns `null` if the input doesn't have the
+ * `bitcoin:` scheme.
+ *
+ * The address is returned as-is (case preserved) — callers should validate it
+ * separately if they need to ensure it's a well-formed bitcoin address.
+ *
+ * Per BIP21, parameters prefixed with `req-` are required: if the client
+ * doesn't understand any of them, the payment MUST NOT be made. The unknown
+ * required params are surfaced via `unknownRequiredParams` so callers can
+ * decide how to fail.
+ *
+ * @example
+ * parseBip21("bitcoin:bc1q...?amount=0.001&lightning=lnbc...")
+ * // => { address: "bc1q...", amount: 0.001, amountSats: 100000, lightning: "lnbc...", ... }
+ */
+export const parseBip21 = (uri: string): Bip21 | null => {
+  if (typeof uri !== "string" || !BIP21_SCHEME.test(uri)) {
+    return null;
+  }
+
+  const withoutScheme = uri.replace(BIP21_SCHEME, "");
+  const queryStart = withoutScheme.indexOf("?");
+  const address =
+    queryStart === -1 ? withoutScheme : withoutScheme.slice(0, queryStart);
+  const query = queryStart === -1 ? "" : withoutScheme.slice(queryStart + 1);
+
+  const params: Record<string, string> = {};
+  const unknownRequiredParams: string[] = [];
+
+  if (query) {
+    // URLSearchParams handles decoding and repeated params; for BIP21 last-write-wins
+    // is fine since the spec doesn't allow repeats.
+    const search = new URLSearchParams(query);
+    search.forEach((value, key) => {
+      params[key] = value;
+    });
+  }
+
+  const knownParams = new Set([
+    "amount",
+    "label",
+    "message",
+    "lightning",
+    "lno",
+  ]);
+
+  for (const key of Object.keys(params)) {
+    if (key.startsWith("req-") && !knownParams.has(key.slice(4))) {
+      unknownRequiredParams.push(key);
+    }
+  }
+
+  const result: Bip21 = {
+    address: address.trim(),
+    params,
+    unknownRequiredParams,
+  };
+
+  if (params.amount !== undefined) {
+    const amount = Number(params.amount);
+    if (Number.isFinite(amount) && amount >= 0) {
+      result.amount = amount;
+      result.amountSats = Math.round(amount * 1e8);
+    }
+  }
+  if (params.label !== undefined) result.label = params.label;
+  if (params.message !== undefined) result.message = params.message;
+  if (params.lightning !== undefined) result.lightning = params.lightning;
+  if (params.lno !== undefined) result.lno = params.lno;
+
+  return result;
+};
+
+/** Returns true if the input starts with the `bitcoin:` URI scheme. */
+export const isBip21 = (uri: string): boolean =>
+  typeof uri === "string" && BIP21_SCHEME.test(uri);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./lnurl";
 export * from "./podcasting2";
 export * from "./402";
 export * from "./fiat";
+export * from "./bip21";


### PR DESCRIPTION
## Summary

Adds a BIP21 (`bitcoin:` URI) parser as a new `@getalby/lightning-tools/bip21` subpath, also re-exported from the root entry.

- `parseBip21(uri)` — returns `{ address, amount, amountSats, label, message, lightning, lno, unknownRequiredParams, params }` or `null` if the input isn't a `bitcoin:` URI.
- `isBip21(uri)` — small predicate for callers that just need a check.
- Handles the unified-QR `lightning=` fallback (BOLT11 / LNURL) and `lno=` (BOLT12 offer).
- Surfaces unknown `req-*` parameters per the BIP21 rule that clients MUST reject URIs they can't fully understand.
- Amount is exposed both as BTC (BIP21's native unit) and pre-converted to sats for convenience.

## Why here

BIP21 is a payment-intent parsing concern, which is the same job lightning-tools already does for lightning addresses, LNURL, and BOLT11. It's also the natural home for the unified-QR `lightning=` extension. `@getalby/sdk` is more about *talking to* services (NWC, OAuth, Alby API), so a pure URI parser fits better in `lightning-tools`.

Address validation is intentionally **not** done — the parser hands back the raw address and lets the caller decide on validation rules.

## Test plan

- [x] `yarn test src/bip21` — 13 tests covering bare URIs, scheme case-insensitivity, amount + sat conversion, invalid amounts, label/message decoding, lightning + lno params, `req-*` handling, raw params, and whitespace trimming
- [x] `yarn lint` clean
- [x] `yarn build` — emits `dist/esm/bip21.js`, `dist/cjs/bip21.cjs`, `dist/types/bip21.d.ts`
- [ ] Manual: import from `@getalby/lightning-tools` (root) and `@getalby/lightning-tools/bip21` (subpath) in a downstream project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BIP21 (bitcoin:) URI support: parse Bitcoin payment URIs to extract address, amount (with satoshi conversion), label, message, lightning fallback, and raw params; detects unknown required params.
  * Added a helper to identify BIP21 URIs.

* **Documentation**
  * Updated README with BIP21 documentation and streamlined usage examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/getAlby/js-lightning-tools/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->