### PR TITLE
feat: return payment in 402 fetch response, allow passing existing credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ This library includes functions to consome those resources.
 - url: the protected URL
 - fetchArgs: arguments are passed to the underlying `fetch()` function used to do the HTTP request
 - options:
-  - wallet: any object that implements `payInvoice({ invoice })` and returns `{ preimage }`. Used to pay L402, X402 and MPP invoices.
+  - wallet: any object that implements `payInvoice({ invoice })` and returns `{ preimage, fees_paid? }`. Used to pay L402, X402 and MPP invoices.
+  - credentials (optional): a credential from a previous paid request (`response.payment.credentials`). When provided it is applied to the request before it is sent so the server can authorize it without a new payment — see [Payment info & polling](#payment-info--polling).
 
 ##### Examples
 
@@ -196,14 +197,51 @@ const nwc = new NWCClient({
   nostrWalletConnectUrl: "nostr+walletconnect://...",
 });
 
-await fetch402(
-  "https://example.com/protected-resource",
-  {},
-  { wallet: nwc },
-)
+await fetch402("https://example.com/protected-resource", {}, { wallet: nwc })
   .then((res) => res.json())
   .then(console.log)
   .finally(() => nwc.close());
+```
+
+#### Payment info & polling
+
+All of the 402 fetch helpers (`fetch402`, `fetchWithL402`, `fetchWithX402`, `fetchWithMpp`) return a standard `fetch` `Response`. When a payment was made (or a supplied credential was reused) the response also carries a `payment` property:
+
+```ts
+interface PaymentInfo {
+  paid: boolean; // whether a lightning payment was made for this request
+  amount: number; // amount of the paid invoice, in satoshis (0 when paid is false)
+  feesPaid?: number; // routing fees in millisatoshis, when reported by the wallet
+  preimage?: string; // payment preimage, when a payment was made
+  credentials: {
+    // reusable credential — pass back via options.credentials
+    header: string; // e.g. "Authorization" (L402/MPP) or "payment-signature" (x402)
+    value: string;
+  };
+}
+```
+
+This lets you inspect what a request cost, and — by passing `credentials` back on a follow-up request — authorize subsequent calls without paying again (e.g. polling a long-running video/song generation job).
+
+> **Important:** when you pass `credentials`, the helper reuses them and **never pays a second time**. If the server still responds with a `402` (e.g. the credential expired or the balance is depleted), that `402` response is returned to you as-is — the library will not silently pay another invoice. You decide what to do next: retry the same credential, or make a fresh unauthenticated request to pay again.
+
+```js
+// First request (no credentials): pays once and returns the content plus a reusable credential
+const res = await fetch402(url, { method: "POST", body }, { wallet: nwc });
+const job = await res.json();
+console.info(`Paid ${res.payment.amount} sats`);
+
+// Follow-up requests reuse the credential — these NEVER pay again
+const pollRes = await fetch402(
+  `${url}/status/${job.id}`,
+  {},
+  { wallet: nwc, credentials: res.payment.credentials },
+);
+if (pollRes.status === 402) {
+  // credential not (yet) accepted — retry the same credential later, do not re-pay
+} else {
+  console.info(await pollRes.json());
+}
 ```
 
 #### L402
@@ -219,7 +257,8 @@ This library includes a `fetchWithL402` function to consume L402 protected resou
 - url: the L402 protected URL
 - fetchArgs: arguments are passed to the underlying `fetch()` function used to do the HTTP request
 - options:
-  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage }`. Used to pay the L402 invoice.
+  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage, fees_paid? }`. Used to pay the L402 invoice.
+  - credentials (optional): a credential from a previous paid request — see [Payment info & polling](#payment-info--polling).
 
 ##### Examples
 
@@ -244,9 +283,9 @@ await fetchWithL402(
 #### X402
 
 Similar to L402 X402 is an open protocol for machine-to-machine payments built on the HTTP 402 Payment Required status code.
-It enables APIs and resources to request payments inline, without prior registration or authentication. 
+It enables APIs and resources to request payments inline, without prior registration or authentication.
 
-This library includes a `fetchWithX402` function to consume X402-protected resources that support the lightning network. 
+This library includes a `fetchWithX402` function to consume X402-protected resources that support the lightning network.
 (Note: X402 works also with other coins and network. This library supports X402 resources that accept Bitcoin on the lightning network)
 
 ##### fetchWithX402(url: string, fetchArgs, options)
@@ -254,7 +293,8 @@ This library includes a `fetchWithX402` function to consume X402-protected resou
 - url: the X402 protected URL
 - fetchArgs: arguments are passed to the underlying `fetch()` function used to do the HTTP request
 - options:
-  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage }`. Used to pay the X402 invoice.
+  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage, fees_paid? }`. Used to pay the X402 invoice.
+  - credentials (optional): a credential from a previous paid request — see [Payment info & polling](#payment-info--polling).
 
 ##### Examples
 
@@ -281,7 +321,7 @@ await fetchWithX402(
 MPP is an open protocol for machine-to-machine payments built on the HTTP 402 Payment Required status code.
 Charge for API requests, tool calls, or content—agents and apps pay per request in the same HTTP call.
 
-This library includes a `fetchWithMpp` function to consume MPP-protected resources that support the lightning network. 
+This library includes a `fetchWithMpp` function to consume MPP-protected resources that support the lightning network.
 (Note: MPP works also with other payment methods. This library supports resources that accept Bitcoin on the lightning network)
 
 ##### fetchWithMpp(url: string, fetchArgs, options)
@@ -289,7 +329,8 @@ This library includes a `fetchWithMpp` function to consume MPP-protected resourc
 - url: the MPP protected URL
 - fetchArgs: arguments are passed to the underlying `fetch()` function used to do the HTTP request
 - options:
-  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage }`. Used to pay the X402 invoice.
+  - wallet: any object (e.g. a NWC client) that implements `payInvoice({ invoice })` and returns `{ preimage, fees_paid? }`. Used to pay the MPP invoice.
+  - credentials (optional): a credential from a previous paid request — see [Payment info & polling](#payment-info--polling).
 
 ##### Examples
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getalby/lightning-tools",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "description": "Collection of helpful building blocks and tools to develop Bitcoin Lightning web apps",
   "type": "module",
   "repository": "https://github.com/getAlby/js-lightning-tools.git",

--- a/src/402/fetch402.test.ts
+++ b/src/402/fetch402.test.ts
@@ -170,6 +170,47 @@ describe("fetch402 dispatcher", () => {
     expect(response.status).toBe(200);
   });
 
+  test("attaches payment info after paying a lightning offer", async () => {
+    const wallet = {
+      payInvoice: jest
+        .fn()
+        .mockResolvedValue({ preimage: PREIMAGE, fees_paid: 42 }),
+    };
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "PAYMENT-REQUIRED": paymentRequiredHeader([LIGHTNING_REQUIREMENTS]),
+      },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ paid: true }), { status: 200 });
+
+    const response = await fetch402(URL, {}, { wallet });
+
+    expect(response.payment?.paid).toBe(true);
+    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaid).toBe(42);
+    expect(response.payment?.credentials.header).toBe("payment-signature");
+  });
+
+  test("reuses supplied credentials without paying again (polling)", async () => {
+    const wallet = makeWallet();
+    const credentials = { header: "payment-signature", value: "cached-sig" };
+
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "processing" }), {
+      status: 200,
+    });
+
+    const response = await fetch402(URL, {}, { wallet, credentials });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    const callInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((callInit.headers as Headers).get("payment-signature")).toBe(
+      "cached-sig",
+    );
+    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+  });
+
   test("returns 200 unchanged when there is no 402", async () => {
     const wallet = makeWallet();
 

--- a/src/402/fetch402.ts
+++ b/src/402/fetch402.ts
@@ -1,4 +1,11 @@
-import { Wallet, createGuardedWallet } from "./utils";
+import {
+  applyCredentials,
+  attachPayment,
+  createGuardedWallet,
+  Fetch402Options,
+  PaidResponse,
+  reusedCredentialPayment,
+} from "./utils";
 import { handleL402Payment } from "./l402/l402";
 import { findX402LightningRequirements, handleX402Payment } from "./x402/x402";
 import { handleMppChargePayment } from "./mpp/mpp";
@@ -7,11 +14,10 @@ import { parseMppChallenge } from "./mpp/utils";
 export const fetch402 = async (
   url: string,
   fetchArgs: RequestInit,
-  options: {
-    wallet: Wallet;
+  options: Fetch402Options & {
     maxAmount?: number;
   },
-) => {
+): Promise<PaidResponse> => {
   const wallet = options.maxAmount
     ? createGuardedWallet(options.wallet, options.maxAmount)
     : options.wallet;
@@ -22,6 +28,19 @@ export const fetch402 = async (
   fetchArgs.mode = "cors";
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
+
+  // If the caller supplied a credential, we MUST use it and never pay again —
+  // even if the server still responds with a 402. Re-paying here is the exact
+  // double-charge this API exists to prevent; the caller decides what to do
+  // with a rejected credential (retry after settlement, top up, etc.).
+  if (options.credentials) {
+    applyCredentials(headers, options.credentials);
+    const reusedResp = await fetch(url, fetchArgs);
+    return attachPayment(
+      reusedResp,
+      reusedCredentialPayment(options.credentials),
+    );
+  }
 
   const initResp = await fetch(url, fetchArgs);
 

--- a/src/402/l402/l402.test.ts
+++ b/src/402/l402/l402.test.ts
@@ -7,6 +7,9 @@ const MACAROON =
   "AgEEbHNhdAJCAAAClGOZrh7C569Yc7UMk8merfnMdIviyXr1qscW7VgpChNl21LkZ8Jex5QiPp+E1VaabeJDuWmlrh/j583axFpNAAIXc2VydmljZXM9cmFuZG9tbnVtYmVyOjAAAiZyYW5kb21udW1iZXJfY2FwYWJpbGl0aZVzPWFkZCxzdWJ0cmFjdAAABiAvFpzXGyc+8d/I9nMKKvAYP8w7kUlhuxS0eFN2sqmqHQ==";
 const INVOICE =
   "lnbc100n1pjkse4mpp5q22x8xdwrmpw0t6cww6sey7fn6klnnr5303vj7h44tr3dm2c9y9qdq8f4f5z4qcqzzsxqyz5vqsp5mmhp6cx4xxysc8xvxaj984eue9pm83lxgezmk3umx6wxr9rrq2ns9qyyssqmmrrwthves6z3d85nafj2ds4z20qju2vpaatep8uwrvxz0xs4kznm99m7f6pmkzax09k2k9saldy34z0p0l8gm0zm5xsmg2g667pnlqp7a0qdz";
+// A real, decodable 402-sat invoice used where the payment amount is asserted.
+const REAL_INVOICE =
+  "lnbc4020n1p5m6028dq80q6rqvsnp4qt5w34u6kntf5lc50jj27rvs89sgrpcpj7s6vfts042gkhxx2j6swpp5g6tquvmswkv5xf0ru7ju2qvdrf83l2ewha3qzzt0a7vurs5q30rssp54kt5hfzjngjersx8fgt60feuu8e7vnat67f3ksr98twdj7z0m0ls9qyysgqcqzp2xqyz5vqrzjqdc22wfv6lyplagj37n9dmndkrzdz8rh3lxkewvvk6arkjpefats2rf47yqqwysqqcqqqqlgqqqqqqgqfqrzjq26922n6s5n5undqrf78rjjhgpcczafws45tx8237y7pzx3fg8ww8apyqqqqqqqqjyqqqqlgqqqqr4gq2q3z5pu33awfm98ac3ysdhy046xmen4zqval67tccu35x9mxgvl6w3wmq6y03ae7pme6qr20mp5gvuqntnu8yy7nlf6gyt9zshanj2zhgqe4xde3";
 const PREIMAGE =
   "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
 
@@ -112,6 +115,106 @@ describe("fetchWithL402", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ data: "paid content" });
+  });
+
+  test("attaches payment info (credentials, amount, fee) after paying", async () => {
+    const wallet = {
+      payInvoice: jest
+        .fn()
+        .mockResolvedValue({ preimage: PREIMAGE, fees_paid: 1000 }),
+    };
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "www-authenticate": makeL402AuthenticateHeader({
+          token: MACAROON,
+          invoice: REAL_INVOICE,
+        }),
+      },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ data: "paid content" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithL402(L402_URL, {}, { wallet });
+
+    expect(response.payment).toEqual({
+      paid: true,
+      amount: 402, // lnbc4020n = 402 sats
+      feesPaid: 1000,
+      preimage: PREIMAGE,
+      credentials: {
+        header: "Authorization",
+        value: `L402 ${MACAROON}:${PREIMAGE}`,
+      },
+    });
+  });
+
+  test("does not attach payment info on free content", async () => {
+    const wallet = makeWallet();
+    fetchMock.mockResponseOnce(JSON.stringify({ ok: true }), { status: 200 });
+
+    const response = await fetchWithL402(L402_URL, {}, { wallet });
+
+    expect(response.payment).toBeUndefined();
+  });
+
+  test("reuses supplied credentials without paying again (polling)", async () => {
+    const wallet = makeWallet();
+    const credentials = {
+      header: "Authorization",
+      value: `L402 ${MACAROON}:${PREIMAGE}`,
+    };
+
+    // Server accepts the reused credential directly (no 402 challenge)
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "processing" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithL402(L402_URL, {}, { wallet, credentials });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // The credential was applied to the request
+    const callInit = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = callInit.headers as Headers;
+    expect(headers.get("Authorization")).toBe(credentials.value);
+
+    // and echoed back so the caller can keep polling
+    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+  });
+
+  test("NEVER pays again when supplied credentials are rejected with a fresh 402", async () => {
+    // Core guarantee: once a credential is supplied, reuse it and NEVER pay a
+    // second invoice — even if the server rejects it with a new challenge. The
+    // 402 is returned so the caller decides (retry after settlement, top up).
+    const wallet = makeWallet();
+    const credentials = {
+      header: "Authorization",
+      value: "L402 stale:credential",
+    };
+
+    // Server rejects the reused credential with a fresh challenge
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "www-authenticate": makeL402AuthenticateHeader({
+          token: MACAROON,
+          invoice: INVOICE,
+        }),
+      },
+    });
+
+    const response = await fetchWithL402(L402_URL, {}, { wallet, credentials });
+
+    // No payment was made, and only the single (credentialed) request was sent.
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(402);
+    // The supplied credential is echoed back so the caller can retry it later.
+    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
   });
 
   test("propagates wallet.payInvoice errors", async () => {

--- a/src/402/l402/l402.ts
+++ b/src/402/l402/l402.ts
@@ -1,4 +1,12 @@
-import { Wallet } from "../utils";
+import {
+  applyCredentials,
+  attachPayment,
+  Fetch402Options,
+  getInvoiceAmount,
+  PaidResponse,
+  reusedCredentialPayment,
+  Wallet,
+} from "../utils";
 import { parseL402 } from "./utils";
 
 export const handleL402Payment = async (
@@ -7,7 +15,7 @@ export const handleL402Payment = async (
   fetchArgs: RequestInit,
   headers: Headers,
   wallet: Wallet,
-): Promise<Response> => {
+): Promise<PaidResponse> => {
   const details = parseL402(l402Header);
   const token = details.token || details.macaroon;
   const invoice = details.invoice;
@@ -20,17 +28,23 @@ export const handleL402Payment = async (
   }
 
   const invResp = await wallet.payInvoice({ invoice });
-  headers.set("Authorization", `L402 ${token}:${invResp.preimage}`);
-  return fetch(url, fetchArgs);
+  const value = `L402 ${token}:${invResp.preimage}`;
+  headers.set("Authorization", value);
+  const response = await fetch(url, fetchArgs);
+  return attachPayment(response, {
+    paid: true,
+    amount: getInvoiceAmount(invoice),
+    feesPaid: invResp.fees_paid,
+    preimage: invResp.preimage,
+    credentials: { header: "Authorization", value },
+  });
 };
 
 export const fetchWithL402 = async (
   url: string,
   fetchArgs: RequestInit,
-  options: {
-    wallet: Wallet;
-  },
-) => {
+  options: Fetch402Options,
+): Promise<PaidResponse> => {
   const wallet = options.wallet;
   if (!wallet) {
     throw new Error("wallet is missing");
@@ -42,6 +56,19 @@ export const fetchWithL402 = async (
   fetchArgs.mode = "cors";
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
+
+  // If the caller supplied a credential, we MUST use it and never pay again —
+  // even if the server still responds with a 402. Re-paying here is the exact
+  // double-charge this API exists to prevent; the caller decides what to do
+  // with a rejected credential (retry after settlement, top up, etc.).
+  if (options.credentials) {
+    applyCredentials(headers, options.credentials);
+    const reusedResp = await fetch(url, fetchArgs);
+    return attachPayment(
+      reusedResp,
+      reusedCredentialPayment(options.credentials),
+    );
+  }
 
   const initResp = await fetch(url, fetchArgs);
   const header = initResp.headers.get("www-authenticate");

--- a/src/402/l402/l402.ts
+++ b/src/402/l402/l402.ts
@@ -19,6 +19,9 @@ export const handleL402Payment = async (
   const details = parseL402(l402Header);
   const token = details.token || details.macaroon;
   const invoice = details.invoice;
+  // Preserve the scheme the server challenged with (L402 or LSAT) so the
+  // retry's Authorization header matches what the server expects.
+  const scheme = /^\s*LSAT\b/i.test(l402Header) ? "LSAT" : "L402";
 
   if (!token) {
     throw new Error("L402: missing token/macaroon in WWW-Authenticate header");
@@ -28,7 +31,7 @@ export const handleL402Payment = async (
   }
 
   const invResp = await wallet.payInvoice({ invoice });
-  const value = `L402 ${token}:${invResp.preimage}`;
+  const value = `${scheme} ${token}:${invResp.preimage}`;
   headers.set("Authorization", value);
   const response = await fetch(url, fetchArgs);
   return attachPayment(response, {

--- a/src/402/mpp/mpp.test.ts
+++ b/src/402/mpp/mpp.test.ts
@@ -33,6 +33,15 @@ const CHARGE_REQUEST: MppChargeRequest = {
 
 const ENCODED_REQUEST = encodeMppChargeRequest(CHARGE_REQUEST);
 
+// A real, decodable 402-sat invoice used where the payment amount is asserted.
+const REAL_INVOICE =
+  "lnbc4020n1p5m6028dq80q6rqvsnp4qt5w34u6kntf5lc50jj27rvs89sgrpcpj7s6vfts042gkhxx2j6swpp5g6tquvmswkv5xf0ru7ju2qvdrf83l2ewha3qzzt0a7vurs5q30rssp54kt5hfzjngjersx8fgt60feuu8e7vnat67f3ksr98twdj7z0m0ls9qyysgqcqzp2xqyz5vqrzjqdc22wfv6lyplagj37n9dmndkrzdz8rh3lxkewvvk6arkjpefats2rf47yqqwysqqcqqqqlgqqqqqqgqfqrzjq26922n6s5n5undqrf78rjjhgpcczafws45tx8237y7pzx3fg8ww8apyqqqqqqqqjyqqqqlgqqqqr4gq2q3z5pu33awfm98ac3ysdhy046xmen4zqval67tccu35x9mxgvl6w3wmq6y03ae7pme6qr20mp5gvuqntnu8yy7nlf6gyt9zshanj2zhgqe4xde3";
+const ENCODED_REAL_REQUEST = encodeMppChargeRequest({
+  amount: "402",
+  currency: "sat",
+  methodDetails: { invoice: REAL_INVOICE },
+});
+
 function makeWallet(preimage: string = PREIMAGE) {
   return {
     payInvoice: jest.fn().mockResolvedValue({ preimage }),
@@ -319,6 +328,63 @@ describe("fetchWithMpp", () => {
     const decoded = JSON.parse(decodeBase64url(token));
 
     expect(decoded.challenge.expires).toBe(expires);
+  });
+
+  test("attaches payment info (credentials, amount, fee) after paying", async () => {
+    const wallet = {
+      payInvoice: jest
+        .fn()
+        .mockResolvedValue({ preimage: PREIMAGE, fees_paid: 250 }),
+    };
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "www-authenticate": makeMppWwwAuthenticateHeader({
+          id: CHALLENGE_ID,
+          realm: REALM,
+          request: ENCODED_REAL_REQUEST,
+        }),
+      },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ data: "paid content" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithMpp(MPP_URL, {}, { wallet });
+
+    expect(response.payment?.paid).toBe(true);
+    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaid).toBe(250);
+    expect(response.payment?.preimage).toBe(PREIMAGE);
+    expect(response.payment?.credentials.header).toBe("Authorization");
+    // The returned credential is exactly the Authorization value that was sent
+    const sentHeaders = (fetchMock.mock.calls[1][1] as RequestInit)
+      .headers as Headers;
+    expect(response.payment?.credentials.value).toBe(
+      sentHeaders.get("Authorization"),
+    );
+  });
+
+  test("reuses supplied credentials without paying again (polling)", async () => {
+    const wallet = makeWallet();
+    const credentials = {
+      header: "Authorization",
+      value: "Payment cached-token",
+    };
+
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "processing" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithMpp(MPP_URL, {}, { wallet, credentials });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    const callInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((callInit.headers as Headers).get("Authorization")).toBe(
+      credentials.value,
+    );
+    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
   });
 
   test("sets cache to no-store and mode to cors", async () => {

--- a/src/402/mpp/mpp.ts
+++ b/src/402/mpp/mpp.ts
@@ -1,4 +1,12 @@
-import { Wallet } from "../utils";
+import {
+  applyCredentials,
+  attachPayment,
+  Fetch402Options,
+  getInvoiceAmount,
+  PaidResponse,
+  reusedCredentialPayment,
+  Wallet,
+} from "../utils";
 import {
   buildMppCredential,
   decodeBase64url,
@@ -23,7 +31,7 @@ export const handleMppChargePayment = async (
   fetchArgs: RequestInit,
   headers: Headers,
   wallet: Wallet,
-): Promise<Response> => {
+): Promise<PaidResponse> => {
   const challenge = parseMppChallenge(wwwAuthHeader);
   if (!challenge) {
     throw new Error(
@@ -49,9 +57,17 @@ export const handleMppChargePayment = async (
 
   // Per spec: Authorization: Payment <base64url-token>  (single token, no wrapper)
   const credential = buildMppCredential(challenge, invResp.preimage);
-  headers.set("Authorization", `Payment ${credential}`);
+  const value = `Payment ${credential}`;
+  headers.set("Authorization", value);
 
-  return fetch(url, fetchArgs);
+  const response = await fetch(url, fetchArgs);
+  return attachPayment(response, {
+    paid: true,
+    amount: getInvoiceAmount(invoice),
+    feesPaid: invResp.fees_paid,
+    preimage: invResp.preimage,
+    credentials: { header: "Authorization", value },
+  });
 };
 
 /**
@@ -63,15 +79,17 @@ export const handleMppChargePayment = async (
  * the function pays the embedded BOLT11 invoice and retries with the
  * resulting preimage as the credential.
  *
- * Note: lightning-charge uses consume-once challenge semantics – each
- * challenge embeds a fresh invoice, so paid credentials cannot be reused.
- * The `store` option is accepted for API consistency but is not used.
+ * Pass a previous credential via `options.credentials` to reuse it (e.g. when
+ * polling); the credential is applied and the function NEVER pays again, even
+ * if the server still responds with a 402 (that response is returned as-is).
+ * Note: lightning-charge typically uses consume-once challenge semantics, so a
+ * reused credential is only accepted by servers that explicitly support it.
  */
 export const fetchWithMpp = async (
   url: string,
   fetchArgs: RequestInit,
-  options: { wallet: Wallet },
-): Promise<Response> => {
+  options: Fetch402Options,
+): Promise<PaidResponse> => {
   const wallet = options.wallet;
   if (!wallet) {
     throw new Error("wallet is missing");
@@ -83,6 +101,19 @@ export const fetchWithMpp = async (
   fetchArgs.mode = "cors";
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
+
+  // If the caller supplied a credential, we MUST use it and never pay again —
+  // even if the server still responds with a 402. Re-paying here is the exact
+  // double-charge this API exists to prevent; the caller decides what to do
+  // with a rejected credential (retry after settlement, top up, etc.).
+  if (options.credentials) {
+    applyCredentials(headers, options.credentials);
+    const reusedResp = await fetch(url, fetchArgs);
+    return attachPayment(
+      reusedResp,
+      reusedCredentialPayment(options.credentials),
+    );
+  }
 
   const initResp = await fetch(url, fetchArgs);
   const wwwAuthHeader = initResp.headers.get("www-authenticate");

--- a/src/402/utils.ts
+++ b/src/402/utils.ts
@@ -1,8 +1,93 @@
 import { Invoice } from "../bolt11/Invoice";
 
 export interface Wallet {
-  payInvoice(args: { invoice: string }): Promise<{ preimage: string }>;
+  payInvoice(args: {
+    invoice: string;
+  }): Promise<{ preimage: string; fees_paid?: number }>;
 }
+
+/**
+ * A reusable payment credential. After a successful paid request the credential
+ * is attached to the response (see {@link PaymentInfo}). Pass it back via
+ * `options.credentials` on a follow-up request (e.g. polling a long-running
+ * job) to authorize the request without paying again.
+ *
+ * `header` is the HTTP header the credential is sent in (`Authorization` for
+ * L402/MPP, `payment-signature` for x402) and `value` is the header value.
+ */
+export interface PaymentCredentials {
+  header: string;
+  value: string;
+}
+
+/**
+ * Payment metadata attached (as `response.payment`) to responses returned by
+ * the 402 fetch helpers.
+ */
+export interface PaymentInfo {
+  /** Whether a lightning payment was made to obtain this response. */
+  paid: boolean;
+  /** Amount of the paid invoice, in satoshis (0 when `paid` is false). */
+  amount: number;
+  /** Routing fees paid, in millisatoshis, when reported by the wallet. */
+  feesPaid?: number;
+  /** Payment preimage, present when a payment was made. */
+  preimage?: string;
+  /**
+   * Reusable credential. Pass it back via `options.credentials` on a follow-up
+   * request (e.g. polling) to authorize it without paying again.
+   */
+  credentials: PaymentCredentials;
+}
+
+/** A `Response` with optional payment metadata attached by the 402 helpers. */
+export type PaidResponse = Response & { payment?: PaymentInfo };
+
+/** Options accepted by the 402 fetch helpers. */
+export interface Fetch402Options {
+  wallet: Wallet;
+  /**
+   * A credential returned by a previous paid request. When provided it is
+   * applied to the request and the helper NEVER pays again — even if the server
+   * still responds with a 402 (that response is returned to the caller as-is).
+   * Use it to authorize follow-up requests (e.g. polling) without re-paying.
+   */
+  credentials?: PaymentCredentials;
+}
+
+/** Apply a previously-obtained credential to the outgoing request headers. */
+export const applyCredentials = (
+  headers: Headers,
+  credentials: PaymentCredentials,
+): void => {
+  headers.set(credentials.header, credentials.value);
+};
+
+/** Attach payment metadata to a response and return it (typed). */
+export const attachPayment = (
+  response: Response,
+  payment: PaymentInfo | undefined,
+): PaidResponse => {
+  if (payment) {
+    (response as PaidResponse).payment = payment;
+  }
+  return response;
+};
+
+/** Payment metadata describing a request authorized with a reused credential. */
+export const reusedCredentialPayment = (
+  credentials: PaymentCredentials | undefined,
+): PaymentInfo | undefined =>
+  credentials ? { paid: false, amount: 0, credentials } : undefined;
+
+/** Satoshi amount of a BOLT11 invoice (0 when it cannot be decoded). */
+export const getInvoiceAmount = (invoice: string): number => {
+  try {
+    return new Invoice({ pr: invoice }).satoshi;
+  } catch (_) {
+    return 0;
+  }
+};
 
 export function createGuardedWallet(
   wallet: Wallet,

--- a/src/402/x402/x402.test.ts
+++ b/src/402/x402/x402.test.ts
@@ -96,6 +96,54 @@ describe("fetchWithX402", () => {
     expect(sig.accepted).toEqual(REQUIREMENTS);
   });
 
+  test("attaches payment info (credentials, amount, fee) after paying", async () => {
+    const wallet = {
+      payInvoice: jest
+        .fn()
+        .mockResolvedValue({ preimage: PREIMAGE, fees_paid: 500 }),
+    };
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: { "PAYMENT-REQUIRED": makePaymentRequiredHeader() },
+    });
+    fetchMock.mockResponseOnce(JSON.stringify({ data: "paid content" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithX402(X402_URL, {}, { wallet });
+
+    expect(response.payment?.paid).toBe(true);
+    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaid).toBe(500);
+    expect(response.payment?.preimage).toBe(PREIMAGE);
+    expect(response.payment?.credentials.header).toBe("payment-signature");
+    // The returned credential is exactly the payment-signature that was sent
+    const sentSig = (fetchMock.mock.calls[1][1] as RequestInit)
+      .headers as Headers;
+    expect(response.payment?.credentials.value).toBe(
+      sentSig.get("payment-signature"),
+    );
+  });
+
+  test("reuses supplied credentials without paying again (polling)", async () => {
+    const wallet = makeWallet();
+    const credentials = { header: "payment-signature", value: "cached-sig" };
+
+    fetchMock.mockResponseOnce(JSON.stringify({ status: "processing" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithX402(X402_URL, {}, { wallet, credentials });
+
+    expect(wallet.payInvoice).not.toHaveBeenCalled();
+    const callInit = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((callInit.headers as Headers).get("payment-signature")).toBe(
+      "cached-sig",
+    );
+    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+  });
+
   test("pays invoice on every request (no caching)", async () => {
     const wallet = makeWallet();
 

--- a/src/402/x402/x402.ts
+++ b/src/402/x402/x402.ts
@@ -1,4 +1,11 @@
-import { Wallet } from "../utils";
+import {
+  applyCredentials,
+  attachPayment,
+  Fetch402Options,
+  PaidResponse,
+  reusedCredentialPayment,
+  Wallet,
+} from "../utils";
 import { buildX402PaymentSignature, X402Requirements } from "./utils";
 import { Invoice } from "../../bolt11";
 
@@ -51,7 +58,7 @@ export const handleX402Payment = async (
   fetchArgs: RequestInit,
   headers: Headers,
   wallet: Wallet,
-): Promise<Response> => {
+): Promise<PaidResponse> => {
   const { accepts } = decodeX402Header(x402Header);
 
   const requirements = accepts.find(
@@ -73,25 +80,30 @@ export const handleX402Payment = async (
     );
   }
 
-  await wallet.payInvoice!({ invoice: invoice.paymentRequest });
+  const invResp = await wallet.payInvoice({ invoice: invoice.paymentRequest });
 
-  headers.set(
-    "payment-signature",
-    buildX402PaymentSignature(
-      requirements.scheme,
-      requirements.network,
-      invoice.paymentRequest,
-      requirements,
-    ),
+  const value = buildX402PaymentSignature(
+    requirements.scheme,
+    requirements.network,
+    invoice.paymentRequest,
+    requirements,
   );
-  return fetch(url, fetchArgs);
+  headers.set("payment-signature", value);
+  const response = await fetch(url, fetchArgs);
+  return attachPayment(response, {
+    paid: true,
+    amount: invoice.satoshi,
+    feesPaid: invResp.fees_paid,
+    preimage: invResp.preimage,
+    credentials: { header: "payment-signature", value },
+  });
 };
 
 export const fetchWithX402 = async (
   url: string,
   fetchArgs: RequestInit,
-  options: { wallet: Wallet },
-) => {
+  options: Fetch402Options,
+): Promise<PaidResponse> => {
   const wallet = options.wallet;
   if (!fetchArgs) {
     fetchArgs = {};
@@ -100,6 +112,19 @@ export const fetchWithX402 = async (
   fetchArgs.mode = "cors";
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
+
+  // If the caller supplied a credential, we MUST use it and never pay again —
+  // even if the server still responds with a 402. Re-paying here is the exact
+  // double-charge this API exists to prevent; the caller decides what to do
+  // with a rejected credential (retry after settlement, top up, etc.).
+  if (options.credentials) {
+    applyCredentials(headers, options.credentials);
+    const reusedResp = await fetch(url, fetchArgs);
+    return attachPayment(
+      reusedResp,
+      reusedCredentialPayment(options.credentials),
+    );
+  }
 
   const initResp = await fetch(url, fetchArgs);
   const header = initResp.headers.get("PAYMENT-REQUIRED");


### PR DESCRIPTION
Closes https://github.com/getAlby/js-lightning-tools/issues/328

If a credential is passed, fetch will **not** pay. If you still get a 402 and want to re-try/re-pay, don't pass a credential.

I did an E2E test with pullthatupjamie.com. I didn't test MPP or x402.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reusing payment credentials on follow-up requests to prevent duplicate payments.
  * Fetch helpers now return richer payment metadata (paid status, amount, optional fees paid, optional preimage, and credential details).
* **Bug Fixes**
  * Improved “pay + decorate” behavior so payment metadata is attached consistently after successful payment/retry flows.
  * Polling with reused credentials won’t re-pay; if a fresh 402 occurs, the 402 response is returned.
* **Documentation**
  * Updated helper docs and examples with credential reuse and payment info/polling behavior.
* **Tests**
  * Added coverage for credential reuse, payment metadata, and 402/polling edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->