### PR TITLE
fix: make 402 fetch response units clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ All of the 402 fetch helpers (`fetch402`, `fetchWithL402`, `fetchWithX402`, `fet
 ```ts
 interface PaymentInfo {
   paid: boolean; // whether a lightning payment was made for this request
-  amount: number; // amount of the paid invoice, in satoshis (0 when paid is false)
-  feesPaid?: number; // routing fees in millisatoshis, when reported by the wallet
+  amountSat: number; // amount of the paid invoice, in satoshis (0 when paid is false)
+  feesPaidMsat?: number; // routing fees in millisatoshis, when reported by the wallet
   preimage?: string; // payment preimage, when a payment was made
   credentials: {
     // reusable credential — pass back via options.credentials
@@ -229,7 +229,7 @@ This lets you inspect what a request cost, and — by passing `credentials` back
 // First request (no credentials): pays once and returns the content plus a reusable credential
 const res = await fetch402(url, { method: "POST", body }, { wallet: nwc });
 const job = await res.json();
-console.info(`Paid ${res.payment.amount} sats`);
+console.info(`Paid ${res.payment.amountSat} sats`);
 
 // Follow-up requests reuse the credential — these NEVER pay again
 const pollRes = await fetch402(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getalby/lightning-tools",
-  "version": "8.2.0",
+  "version": "9.0.0",
   "description": "Collection of helpful building blocks and tools to develop Bitcoin Lightning web apps",
   "type": "module",
   "repository": "https://github.com/getAlby/js-lightning-tools.git",

--- a/src/402/fetch402.test.ts
+++ b/src/402/fetch402.test.ts
@@ -188,8 +188,8 @@ describe("fetch402 dispatcher", () => {
     const response = await fetch402(URL, {}, { wallet });
 
     expect(response.payment?.paid).toBe(true);
-    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
-    expect(response.payment?.feesPaid).toBe(42);
+    expect(response.payment?.amountSat).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaidMsat).toBe(42);
     expect(response.payment?.credentials.header).toBe("payment-signature");
   });
 
@@ -208,7 +208,11 @@ describe("fetch402 dispatcher", () => {
     expect((callInit.headers as Headers).get("payment-signature")).toBe(
       "cached-sig",
     );
-    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+    expect(response.payment).toEqual({
+      paid: false,
+      amountSat: 0,
+      credentials,
+    });
   });
 
   test("returns 200 unchanged when there is no 402", async () => {

--- a/src/402/l402/l402.test.ts
+++ b/src/402/l402/l402.test.ts
@@ -141,8 +141,8 @@ describe("fetchWithL402", () => {
 
     expect(response.payment).toEqual({
       paid: true,
-      amount: 402, // lnbc4020n = 402 sats
-      feesPaid: 1000,
+      amountSat: 402, // lnbc4020n = 402 sats
+      feesPaidMsat: 1000,
       preimage: PREIMAGE,
       credentials: {
         header: "Authorization",
@@ -183,7 +183,11 @@ describe("fetchWithL402", () => {
     expect(headers.get("Authorization")).toBe(credentials.value);
 
     // and echoed back so the caller can keep polling
-    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+    expect(response.payment).toEqual({
+      paid: false,
+      amountSat: 0,
+      credentials,
+    });
   });
 
   test("NEVER pays again when supplied credentials are rejected with a fresh 402", async () => {
@@ -214,7 +218,11 @@ describe("fetchWithL402", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.status).toBe(402);
     // The supplied credential is echoed back so the caller can retry it later.
-    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+    expect(response.payment).toEqual({
+      paid: false,
+      amountSat: 0,
+      credentials,
+    });
   });
 
   test("propagates wallet.payInvoice errors", async () => {

--- a/src/402/l402/l402.ts
+++ b/src/402/l402/l402.ts
@@ -36,8 +36,8 @@ export const handleL402Payment = async (
   const response = await fetch(url, fetchArgs);
   return attachPayment(response, {
     paid: true,
-    amount: getInvoiceAmount(invoice),
-    feesPaid: invResp.fees_paid,
+    amountSat: getInvoiceAmount(invoice),
+    feesPaidMsat: invResp.fees_paid,
     preimage: invResp.preimage,
     credentials: { header: "Authorization", value },
   });

--- a/src/402/mpp/mpp.test.ts
+++ b/src/402/mpp/mpp.test.ts
@@ -354,8 +354,8 @@ describe("fetchWithMpp", () => {
     const response = await fetchWithMpp(MPP_URL, {}, { wallet });
 
     expect(response.payment?.paid).toBe(true);
-    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
-    expect(response.payment?.feesPaid).toBe(250);
+    expect(response.payment?.amountSat).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaidMsat).toBe(250);
     expect(response.payment?.preimage).toBe(PREIMAGE);
     expect(response.payment?.credentials.header).toBe("Authorization");
     // The returned credential is exactly the Authorization value that was sent
@@ -384,7 +384,11 @@ describe("fetchWithMpp", () => {
     expect((callInit.headers as Headers).get("Authorization")).toBe(
       credentials.value,
     );
-    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+    expect(response.payment).toEqual({
+      paid: false,
+      amountSat: 0,
+      credentials,
+    });
   });
 
   test("sets cache to no-store and mode to cors", async () => {

--- a/src/402/mpp/mpp.ts
+++ b/src/402/mpp/mpp.ts
@@ -63,8 +63,8 @@ export const handleMppChargePayment = async (
   const response = await fetch(url, fetchArgs);
   return attachPayment(response, {
     paid: true,
-    amount: getInvoiceAmount(invoice),
-    feesPaid: invResp.fees_paid,
+    amountSat: getInvoiceAmount(invoice),
+    feesPaidMsat: invResp.fees_paid,
     preimage: invResp.preimage,
     credentials: { header: "Authorization", value },
   });

--- a/src/402/utils.ts
+++ b/src/402/utils.ts
@@ -28,9 +28,9 @@ export interface PaymentInfo {
   /** Whether a lightning payment was made to obtain this response. */
   paid: boolean;
   /** Amount of the paid invoice, in satoshis (0 when `paid` is false). */
-  amount: number;
+  amountSat: number;
   /** Routing fees paid, in millisatoshis, when reported by the wallet. */
-  feesPaid?: number;
+  feesPaidMsat?: number;
   /** Payment preimage, present when a payment was made. */
   preimage?: string;
   /**
@@ -78,7 +78,7 @@ export const attachPayment = (
 export const reusedCredentialPayment = (
   credentials: PaymentCredentials | undefined,
 ): PaymentInfo | undefined =>
-  credentials ? { paid: false, amount: 0, credentials } : undefined;
+  credentials ? { paid: false, amountSat: 0, credentials } : undefined;
 
 /** Satoshi amount of a BOLT11 invoice (0 when it cannot be decoded). */
 export const getInvoiceAmount = (invoice: string): number => {

--- a/src/402/x402/x402.test.ts
+++ b/src/402/x402/x402.test.ts
@@ -114,8 +114,8 @@ describe("fetchWithX402", () => {
     const response = await fetchWithX402(X402_URL, {}, { wallet });
 
     expect(response.payment?.paid).toBe(true);
-    expect(response.payment?.amount).toBe(402); // lnbc4020n = 402 sats
-    expect(response.payment?.feesPaid).toBe(500);
+    expect(response.payment?.amountSat).toBe(402); // lnbc4020n = 402 sats
+    expect(response.payment?.feesPaidMsat).toBe(500);
     expect(response.payment?.preimage).toBe(PREIMAGE);
     expect(response.payment?.credentials.header).toBe("payment-signature");
     // The returned credential is exactly the payment-signature that was sent
@@ -141,7 +141,11 @@ describe("fetchWithX402", () => {
     expect((callInit.headers as Headers).get("payment-signature")).toBe(
       "cached-sig",
     );
-    expect(response.payment).toEqual({ paid: false, amount: 0, credentials });
+    expect(response.payment).toEqual({
+      paid: false,
+      amountSat: 0,
+      credentials,
+    });
   });
 
   test("pays invoice on every request (no caching)", async () => {

--- a/src/402/x402/x402.ts
+++ b/src/402/x402/x402.ts
@@ -92,8 +92,8 @@ export const handleX402Payment = async (
   const response = await fetch(url, fetchArgs);
   return attachPayment(response, {
     paid: true,
-    amount: invoice.satoshi,
-    feesPaid: invResp.fees_paid,
+    amountSat: invoice.satoshi,
+    feesPaidMsat: invResp.fees_paid,
     preimage: invResp.preimage,
     credentials: { header: "payment-signature", value },
   });


### PR DESCRIPTION
Closes https://github.com/getAlby/js-lightning-tools/issues/331

this fixes that the agent things the fee is in sats and shows a huge warning (e.g. paid 1 sat but 1000 sat fee)

this is a breaking change on the response type so I've done a major version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Payment details now use `amountSat` for amounts and `feesPaidMsat` for routing fees.
  - Update integrations and response handling that reference the previous `amount` or `feesPaid` fields.
  - Unpaid or reused-credential responses report `amountSat: 0`.

- **Documentation**
  - Updated payment examples and interface documentation to reflect the new field names.

- **Chores**
  - Package version updated to 9.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->