### PR TITLE
feat: resume fetch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,75 @@ if (pollRes.status === 402) {
 }
 ```
 
+##### Recovering from a failure after paying
+
+If the invoice is paid but the flow then fails (the wallet times out, or the
+request _after_ payment hits a network error), the helper throws a
+`Fetch402PaymentError` instead of a bare `Error`. It carries everything needed
+to reconcile the payment **without paying the same invoice again**:
+
+```ts
+class Fetch402PaymentError extends Error {
+  invoice: string; // the invoice that was paid (or attempted)
+  paymentHash: string; // decoded from the invoice — use it to look up settlement
+  paid: boolean; // whether the wallet reported the payment succeeded
+  preimage?: string; // present when paid
+  credentials?: PaymentCredentials; // present when paid — retry with these
+  pendingPayment: PendingPayment; // opaque token to resume via options.resume
+  cause?: unknown; // the underlying wallet/fetch error
+}
+```
+
+Every field is plain data, so the error survives `JSON.stringify` and can be
+forwarded across process/CLI boundaries. (After a round-trip it's a plain
+object, so match on `e.name === "Fetch402PaymentError"` rather than
+`instanceof`.)
+
+```js
+try {
+  const res = await fetch402(url, { method: "POST", body }, { wallet: nwc });
+} catch (e) {
+  if (e.name !== "Fetch402PaymentError") throw e;
+
+  if (e.paid) {
+    // Payment succeeded but the follow-up request failed. The credential is
+    // already built — retry with it, DON'T pay again.
+    await fetch402(
+      url,
+      { method: "POST", body },
+      { wallet: nwc, credentials: e.credentials },
+    );
+  } else {
+    // payInvoice never returned (e.g. a timeout), but the payment may have
+    // settled anyway. Ask the wallet whether this payment hash settled.
+    const lookup = await nwc.lookupInvoice({ payment_hash: e.paymentHash });
+
+    if (lookup?.preimage) {
+      // It settled — you have ALREADY PAID. Resume the same request: pass the
+      // recovered preimage back with the error's pendingPayment and the library
+      // rebuilds the credential internally and sends it WITHOUT paying again.
+      await fetch402(
+        url,
+        { method: "POST", body },
+        {
+          wallet: nwc,
+          resume: {
+            pendingPayment: e.pendingPayment,
+            preimage: lookup.preimage,
+          },
+        },
+      );
+    } else if (lookup?.state === "failed") {
+      // Explicitly FAILED — no funds moved, safe to retry from scratch.
+      await fetch402(url, { method: "POST", body }, { wallet: nwc });
+    } else {
+      // Still pending / in-flight — do NOT retry yet: it may still settle and a
+      // fresh payment would double-pay. Wait and re-check the payment hash.
+    }
+  }
+}
+```
+
 #### L402
 
 L402 is a protocol standard based on the HTTP 402 Payment Required error code

--- a/src/402/fetch402.ts
+++ b/src/402/fetch402.ts
@@ -1,10 +1,8 @@
 import {
-  applyCredentials,
-  attachPayment,
   createGuardedWallet,
   Fetch402Options,
   PaidResponse,
-  reusedCredentialPayment,
+  tryReusePayment,
 } from "./utils";
 import { handleL402Payment } from "./l402/l402";
 import { findX402LightningRequirements, handleX402Payment } from "./x402/x402";
@@ -29,17 +27,13 @@ export const fetch402 = async (
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
 
-  // If the caller supplied a credential, we MUST use it and never pay again —
-  // even if the server still responds with a 402. Re-paying here is the exact
-  // double-charge this API exists to prevent; the caller decides what to do
-  // with a rejected credential (retry after settlement, top up, etc.).
-  if (options.credentials) {
-    applyCredentials(headers, options.credentials);
-    const reusedResp = await fetch(url, fetchArgs);
-    return attachPayment(
-      reusedResp,
-      reusedCredentialPayment(options.credentials),
-    );
+  // If the caller supplied a credential or a resume token, we MUST use it and
+  // never pay again — even if the server still responds with a 402. Re-paying
+  // here is the exact double-charge this API exists to prevent; the caller
+  // decides what to do next (retry after settlement, top up, etc.).
+  const reused = await tryReusePayment(url, fetchArgs, headers, options);
+  if (reused) {
+    return reused;
   }
 
   const initResp = await fetch(url, fetchArgs);

--- a/src/402/l402/l402.test.ts
+++ b/src/402/l402/l402.test.ts
@@ -2,6 +2,8 @@ import fetchMock from "jest-fetch-mock";
 import { fetchWithL402 } from "./l402";
 import { parseL402 } from "./utils";
 import { makeL402AuthenticateHeader } from "./server/utils";
+import { Fetch402PaymentError } from "../utils";
+import { Invoice } from "../../bolt11";
 
 const MACAROON =
   "AgEEbHNhdAJCAAAClGOZrh7C569Yc7UMk8merfnMdIviyXr1qscW7VgpChNl21LkZ8Jex5QiPp+E1VaabeJDuWmlrh/j583axFpNAAIXc2VydmljZXM9cmFuZG9tbnVtYmVyOjAAAiZyYW5kb21udW1iZXJfY2FwYWJpbGl0aZVzPWFkZCxzdWJ0cmFjdAAABiAvFpzXGyc+8d/I9nMKKvAYP8w7kUlhuxS0eFN2sqmqHQ==";
@@ -227,14 +229,134 @@ describe("fetchWithL402", () => {
       headers: {
         "www-authenticate": makeL402AuthenticateHeader({
           token: MACAROON,
-          invoice: INVOICE,
+          invoice: REAL_INVOICE,
         }),
       },
     });
 
-    await expect(fetchWithL402(L402_URL, {}, { wallet })).rejects.toThrow(
-      "payment failed",
+    const error = await fetchWithL402(L402_URL, {}, { wallet }).catch((e) => e);
+    expect(error).toBeInstanceOf(Fetch402PaymentError);
+    expect(error.paid).toBe(false);
+    expect(error.invoice).toBe(REAL_INVOICE);
+    expect(error.paymentHash).toBe(
+      new Invoice({ pr: REAL_INVOICE }).paymentHash,
     );
+    expect(error.preimage).toBeUndefined();
+    expect(error.credentials).toBeUndefined();
+    // The pendingPayment carries the macaroon so the credential can be rebuilt
+    // once the preimage is recovered (see the resume test below).
+    expect(error.pendingPayment).toEqual({
+      scheme: "l402",
+      header: "Authorization",
+      token: MACAROON,
+      authScheme: "L402",
+    });
+    expect((error.cause as Error).message).toBe("payment failed");
+  });
+
+  test("resumes a timed-out payment without paying again", async () => {
+    // First attempt: payInvoice times out, so we never learned the preimage —
+    // but the payment may have settled on the network.
+    const payingWallet = {
+      payInvoice: jest.fn().mockRejectedValue(new Error("timeout")),
+    };
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "www-authenticate": makeL402AuthenticateHeader({
+          token: MACAROON,
+          invoice: REAL_INVOICE,
+        }),
+      },
+    });
+
+    const error = await fetchWithL402(
+      L402_URL,
+      {},
+      { wallet: payingWallet },
+    ).catch((e) => e);
+    expect(error.paid).toBe(false);
+
+    // Caller looks the payment up by error.paymentHash, finds it settled, and
+    // recovers the preimage from their wallet.
+    const recoveredPreimage = PREIMAGE;
+
+    // Resume: the same fetch, passing back the pendingPayment + recovered
+    // preimage. This MUST NOT pay again.
+    const resumeWallet = {
+      payInvoice: jest
+        .fn()
+        .mockRejectedValue(new Error("should not be called")),
+    };
+    fetchMock.mockResponseOnce(JSON.stringify({ data: "paid content" }), {
+      status: 200,
+    });
+
+    const response = await fetchWithL402(
+      L402_URL,
+      {},
+      {
+        wallet: resumeWallet,
+        resume: {
+          pendingPayment: error.pendingPayment,
+          preimage: recoveredPreimage,
+        },
+      },
+    );
+
+    // No second payment was attempted.
+    expect(resumeWallet.payInvoice).not.toHaveBeenCalled();
+
+    // The rebuilt credential was applied to the resumed request.
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    const headers = (lastCall[1] as RequestInit).headers as Headers;
+    expect(headers.get("Authorization")).toBe(`L402 ${MACAROON}:${PREIMAGE}`);
+
+    // And surfaced on the response (paid:false — this request did not pay).
+    expect(response.status).toBe(200);
+    expect(response.payment).toEqual({
+      paid: false,
+      amount: 0,
+      preimage: PREIMAGE,
+      credentials: {
+        header: "Authorization",
+        value: `L402 ${MACAROON}:${PREIMAGE}`,
+      },
+    });
+  });
+
+  test("throws recoverable Fetch402PaymentError when the request after payment fails", async () => {
+    // The invoice is already paid; a network error on the retry must NOT lose
+    // the preimage/credential (else the caller would pay the same invoice again).
+    const wallet = makeWallet();
+
+    fetchMock.mockResponseOnce("Payment Required", {
+      status: 402,
+      headers: {
+        "www-authenticate": makeL402AuthenticateHeader({
+          token: MACAROON,
+          invoice: REAL_INVOICE,
+        }),
+      },
+    });
+    // Second fetch (after payment) fails at the network level.
+    fetchMock.mockRejectOnce(new Error("network down"));
+
+    const error = await fetchWithL402(L402_URL, {}, { wallet }).catch((e) => e);
+    expect(wallet.payInvoice).toHaveBeenCalledTimes(1);
+    expect(error).toBeInstanceOf(Fetch402PaymentError);
+    expect(error.paid).toBe(true);
+    expect(error.invoice).toBe(REAL_INVOICE);
+    expect(error.paymentHash).toBe(
+      new Invoice({ pr: REAL_INVOICE }).paymentHash,
+    );
+    expect(error.preimage).toBe(PREIMAGE);
+    expect(error.credentials).toEqual({
+      header: "Authorization",
+      value: `L402 ${MACAROON}:${PREIMAGE}`,
+    });
+    expect((error.cause as Error).message).toBe("network down");
   });
 
   test("passes fetchArgs through to the underlying fetch calls", async () => {

--- a/src/402/l402/l402.ts
+++ b/src/402/l402/l402.ts
@@ -1,10 +1,9 @@
 import {
-  applyCredentials,
-  attachPayment,
   Fetch402Options,
   getInvoiceAmount,
   PaidResponse,
-  reusedCredentialPayment,
+  payAndFetch,
+  tryReusePayment,
   Wallet,
 } from "../utils";
 import { parseL402 } from "./utils";
@@ -30,16 +29,19 @@ export const handleL402Payment = async (
     throw new Error("L402: missing invoice in WWW-Authenticate header");
   }
 
-  const invResp = await wallet.payInvoice({ invoice });
-  const value = `${scheme} ${token}:${invResp.preimage}`;
-  headers.set("Authorization", value);
-  const response = await fetch(url, fetchArgs);
-  return attachPayment(response, {
-    paid: true,
+  return payAndFetch({
+    wallet,
+    invoice,
+    url,
+    fetchArgs,
+    headers,
+    pendingPayment: {
+      scheme: "l402",
+      header: "Authorization",
+      token,
+      authScheme: scheme,
+    },
     amount: getInvoiceAmount(invoice),
-    feesPaid: invResp.fees_paid,
-    preimage: invResp.preimage,
-    credentials: { header: "Authorization", value },
   });
 };
 
@@ -60,17 +62,13 @@ export const fetchWithL402 = async (
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
 
-  // If the caller supplied a credential, we MUST use it and never pay again —
-  // even if the server still responds with a 402. Re-paying here is the exact
-  // double-charge this API exists to prevent; the caller decides what to do
-  // with a rejected credential (retry after settlement, top up, etc.).
-  if (options.credentials) {
-    applyCredentials(headers, options.credentials);
-    const reusedResp = await fetch(url, fetchArgs);
-    return attachPayment(
-      reusedResp,
-      reusedCredentialPayment(options.credentials),
-    );
+  // If the caller supplied a credential or a resume token, we MUST use it and
+  // never pay again — even if the server still responds with a 402. Re-paying
+  // here is the exact double-charge this API exists to prevent; the caller
+  // decides what to do next (retry after settlement, top up, etc.).
+  const reused = await tryReusePayment(url, fetchArgs, headers, options);
+  if (reused) {
+    return reused;
   }
 
   const initResp = await fetch(url, fetchArgs);

--- a/src/402/mpp/mpp.test.ts
+++ b/src/402/mpp/mpp.test.ts
@@ -1,5 +1,7 @@
 import fetchMock from "jest-fetch-mock";
 import { fetchWithMpp } from "./mpp";
+import { Fetch402PaymentError } from "../utils";
+import { Invoice } from "../../bolt11";
 import {
   buildMppCredential,
   decodeBase64url,
@@ -439,14 +441,21 @@ describe("fetchWithMpp", () => {
         "www-authenticate": makeMppWwwAuthenticateHeader({
           id: CHALLENGE_ID,
           realm: REALM,
-          request: ENCODED_REQUEST,
+          request: ENCODED_REAL_REQUEST,
         }),
       },
     });
 
-    await expect(fetchWithMpp(MPP_URL, {}, { wallet })).rejects.toThrow(
-      "payment failed",
+    const error = await fetchWithMpp(MPP_URL, {}, { wallet }).catch((e) => e);
+    expect(error).toBeInstanceOf(Fetch402PaymentError);
+    expect(error.paid).toBe(false);
+    expect(error.invoice).toBe(REAL_INVOICE);
+    expect(error.paymentHash).toBe(
+      new Invoice({ pr: REAL_INVOICE }).paymentHash,
     );
+    expect(error.preimage).toBeUndefined();
+    expect(error.credentials).toBeUndefined();
+    expect((error.cause as Error).message).toBe("payment failed");
   });
 
   test("works with minimal options (wallet only)", async () => {

--- a/src/402/mpp/mpp.ts
+++ b/src/402/mpp/mpp.ts
@@ -1,18 +1,12 @@
 import {
-  applyCredentials,
-  attachPayment,
   Fetch402Options,
   getInvoiceAmount,
   PaidResponse,
-  reusedCredentialPayment,
+  payAndFetch,
+  tryReusePayment,
   Wallet,
 } from "../utils";
-import {
-  buildMppCredential,
-  decodeBase64url,
-  MppChargeRequest,
-  parseMppChallenge,
-} from "./utils";
+import { decodeBase64url, MppChargeRequest, parseMppChallenge } from "./utils";
 
 /**
  * Handle a `WWW-Authenticate: Payment …` challenge produced by a
@@ -53,20 +47,14 @@ export const handleMppChargePayment = async (
     throw new Error("mpp: missing invoice in charge request");
   }
 
-  const invResp = await wallet.payInvoice({ invoice });
-
-  // Per spec: Authorization: Payment <base64url-token>  (single token, no wrapper)
-  const credential = buildMppCredential(challenge, invResp.preimage);
-  const value = `Payment ${credential}`;
-  headers.set("Authorization", value);
-
-  const response = await fetch(url, fetchArgs);
-  return attachPayment(response, {
-    paid: true,
+  return payAndFetch({
+    wallet,
+    invoice,
+    url,
+    fetchArgs,
+    headers,
+    pendingPayment: { scheme: "mpp", header: "Authorization", challenge },
     amount: getInvoiceAmount(invoice),
-    feesPaid: invResp.fees_paid,
-    preimage: invResp.preimage,
-    credentials: { header: "Authorization", value },
   });
 };
 
@@ -102,17 +90,13 @@ export const fetchWithMpp = async (
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
 
-  // If the caller supplied a credential, we MUST use it and never pay again —
-  // even if the server still responds with a 402. Re-paying here is the exact
-  // double-charge this API exists to prevent; the caller decides what to do
-  // with a rejected credential (retry after settlement, top up, etc.).
-  if (options.credentials) {
-    applyCredentials(headers, options.credentials);
-    const reusedResp = await fetch(url, fetchArgs);
-    return attachPayment(
-      reusedResp,
-      reusedCredentialPayment(options.credentials),
-    );
+  // If the caller supplied a credential or a resume token, we MUST use it and
+  // never pay again — even if the server still responds with a 402. Re-paying
+  // here is the exact double-charge this API exists to prevent; the caller
+  // decides what to do next (retry after settlement, top up, etc.).
+  const reused = await tryReusePayment(url, fetchArgs, headers, options);
+  if (reused) {
+    return reused;
   }
 
   const initResp = await fetch(url, fetchArgs);

--- a/src/402/utils.ts
+++ b/src/402/utils.ts
@@ -1,4 +1,5 @@
 import { Invoice } from "../bolt11/Invoice";
+import { buildMppCredential, MppChallenge } from "./mpp/utils";
 
 export interface Wallet {
   payInvoice(args: {
@@ -19,6 +20,67 @@ export interface PaymentCredentials {
   header: string;
   value: string;
 }
+
+/**
+ * An interrupted payment that can be resumed once its preimage is recovered.
+ *
+ * When `wallet.payInvoice` times out, the payment may still have settled but the
+ * preimage is lost — so the credential (which embeds the preimage) can't be
+ * built yet. This opaque, fully-serializable token captures everything else the
+ * library needs; hand it back via `options.resume` together with the recovered
+ * preimage and the library rebuilds the credential internally, without paying
+ * again. Treat it as opaque: don't read or construct its fields yourself.
+ *
+ * It is plain data (no functions), so it survives `JSON.stringify` and can be
+ * forwarded across process/CLI boundaries.
+ */
+export type PendingPayment =
+  | {
+      scheme: "l402";
+      header: string;
+      /** The macaroon/token from the L402 challenge. */
+      token: string;
+      /** The challenge scheme, preserved so the retry header matches. */
+      authScheme: "L402" | "LSAT";
+    }
+  | {
+      scheme: "mpp";
+      header: string;
+      /** The parsed MPP challenge, echoed into the credential. */
+      challenge: MppChallenge;
+    }
+  | {
+      scheme: "x402";
+      header: string;
+      /** The x402 payment signature — independent of the preimage. */
+      value: string;
+    };
+
+/**
+ * Rebuild a scheme's {@link PaymentCredentials} from a {@link PendingPayment}
+ * and its recovered preimage. Internal: callers reach this via `options.resume`,
+ * never directly.
+ */
+const buildCredentials = (
+  pendingPayment: PendingPayment,
+  preimage: string,
+): PaymentCredentials => {
+  switch (pendingPayment.scheme) {
+    case "l402":
+      return {
+        header: pendingPayment.header,
+        value: `${pendingPayment.authScheme} ${pendingPayment.token}:${preimage}`,
+      };
+    case "mpp":
+      return {
+        header: pendingPayment.header,
+        value: `Payment ${buildMppCredential(pendingPayment.challenge, preimage)}`,
+      };
+    case "x402":
+      // x402's signature does not embed the preimage; it is already complete.
+      return { header: pendingPayment.header, value: pendingPayment.value };
+  }
+};
 
 /**
  * Payment metadata attached (as `response.payment`) to responses returned by
@@ -53,6 +115,18 @@ export interface Fetch402Options {
    * Use it to authorize follow-up requests (e.g. polling) without re-paying.
    */
   credentials?: PaymentCredentials;
+  /**
+   * Resume a payment that was interrupted by a timeout. When `payInvoice` throws
+   * (see {@link Fetch402PaymentError} with `paid: false`) the payment may still
+   * have settled; look the payment up in your wallet by `paymentHash`, and if it
+   * settled pass the recovered `preimage` back here together with the error's
+   * `pendingPayment`. The helper rebuilds the credential and sends the request
+   * WITHOUT paying again.
+   */
+  resume?: {
+    pendingPayment: PendingPayment;
+    preimage: string;
+  };
 }
 
 /** Apply a previously-obtained credential to the outgoing request headers. */
@@ -80,6 +154,44 @@ export const reusedCredentialPayment = (
 ): PaymentInfo | undefined =>
   credentials ? { paid: false, amount: 0, credentials } : undefined;
 
+/**
+ * If the caller supplied a reusable `credentials` or a `resume` token, apply it
+ * and send the request WITHOUT paying. Returns the finished response, or `null`
+ * when neither was supplied (so the caller proceeds to the normal pay flow).
+ *
+ * Both paths carry the guarantee the 402 helpers exist to provide: once you hand
+ * back a credential or a resumed payment, the library never pays a second time.
+ */
+export const tryReusePayment = async (
+  url: string,
+  fetchArgs: RequestInit,
+  headers: Headers,
+  options: Fetch402Options,
+): Promise<PaidResponse | null> => {
+  if (options.credentials) {
+    applyCredentials(headers, options.credentials);
+    const response = await fetch(url, fetchArgs);
+    return attachPayment(
+      response,
+      reusedCredentialPayment(options.credentials),
+    );
+  }
+  if (options.resume) {
+    const { pendingPayment, preimage } = options.resume;
+    const credentials = buildCredentials(pendingPayment, preimage);
+    applyCredentials(headers, credentials);
+    const response = await fetch(url, fetchArgs);
+    // The payment already happened (earlier); this request itself does not pay.
+    return attachPayment(response, {
+      paid: false,
+      amount: 0,
+      preimage,
+      credentials,
+    });
+  }
+  return null;
+};
+
 /** Satoshi amount of a BOLT11 invoice (0 when it cannot be decoded). */
 export const getInvoiceAmount = (invoice: string): number => {
   try {
@@ -87,6 +199,142 @@ export const getInvoiceAmount = (invoice: string): number => {
   } catch (_) {
     return 0;
   }
+};
+
+/** Payment hash of a BOLT11 invoice (empty string when it cannot be decoded). */
+export const getPaymentHash = (invoice: string): string => {
+  try {
+    return new Invoice({ pr: invoice }).paymentHash;
+  } catch (_) {
+    return "";
+  }
+};
+
+/**
+ * Thrown when a payment was ATTEMPTED but the request flow then failed, leaving
+ * the caller without a `Response`. It carries everything needed to reconcile the
+ * payment WITHOUT paying the same invoice again — the exact double-charge the
+ * 402 helpers exist to prevent.
+ *
+ * - `paid: false` — `wallet.payInvoice` itself rejected. The payment may still
+ *   have settled (e.g. a wallet timeout). Look up `paymentHash` in your wallet;
+ *   if it settled, pass the recovered preimage and `pendingPayment` back via
+ *   `options.resume` (the library rebuilds the credential) instead of re-paying.
+ * - `paid: true` — the invoice was paid but the follow-up request failed (e.g. a
+ *   network error reaching the resource). Retry with `credentials` (already
+ *   built) instead of paying again.
+ *
+ * All fields are plain data so the error survives `JSON.stringify` and can be
+ * forwarded across process/CLI boundaries. Note: after such a round-trip the
+ * value is a plain object, so match on `name === "Fetch402PaymentError"` (or
+ * the presence of `paymentHash`) rather than `instanceof`.
+ */
+export class Fetch402PaymentError extends Error {
+  /** Discriminator that survives serialization (`instanceof` does not). */
+  readonly name = "Fetch402PaymentError";
+  /** The invoice that was paid (or attempted). */
+  readonly invoice: string;
+  /** Payment hash decoded from the invoice; use it to look up settlement. */
+  readonly paymentHash: string;
+  /** Whether `wallet.payInvoice` reported success before the failure. */
+  readonly paid: boolean;
+  /** Payment preimage, present when the invoice was paid. */
+  readonly preimage?: string;
+  /** Reusable credential, present when `paid` (already built for you). */
+  readonly credentials?: PaymentCredentials;
+  /**
+   * The interrupted payment. When `paid` is false, pass this back via
+   * `options.resume` with the recovered preimage to finish without re-paying.
+   */
+  readonly pendingPayment: PendingPayment;
+  /** The underlying error that caused the failure. */
+  readonly cause?: unknown;
+
+  constructor(
+    message: string,
+    details: {
+      invoice: string;
+      paid: boolean;
+      pendingPayment: PendingPayment;
+      preimage?: string;
+      credentials?: PaymentCredentials;
+      cause?: unknown;
+    },
+  ) {
+    super(message);
+    this.invoice = details.invoice;
+    this.paymentHash = getPaymentHash(details.invoice);
+    this.paid = details.paid;
+    this.preimage = details.preimage;
+    this.credentials = details.credentials;
+    this.pendingPayment = details.pendingPayment;
+    this.cause = details.cause;
+  }
+}
+
+/**
+ * Shared tail of every 402 handler: pay the invoice, apply the resulting
+ * credential, retry the request, and attach payment metadata. Any failure
+ * during or after payment is rethrown as {@link Fetch402PaymentError} so a
+ * thrown error never loses the paid invoice/credential and the caller can
+ * reconcile instead of paying twice.
+ */
+export const payAndFetch = async (args: {
+  wallet: Wallet;
+  invoice: string;
+  url: string;
+  fetchArgs: RequestInit;
+  headers: Headers;
+  /** How to build the credential once the preimage is known. */
+  pendingPayment: PendingPayment;
+  /** Invoice amount in satoshis, for the attached PaymentInfo. */
+  amount: number;
+}): Promise<PaidResponse> => {
+  const { wallet, invoice, url, fetchArgs, headers, pendingPayment, amount } =
+    args;
+
+  let invResp: { preimage: string; fees_paid?: number };
+  try {
+    invResp = await wallet.payInvoice({ invoice });
+  } catch (cause) {
+    // Payment may or may not have settled (e.g. a wallet timeout). Surface the
+    // paymentHash (to look up settlement) and the pendingPayment (to resume from
+    // a recovered preimage via options.resume) so the caller need never re-pay.
+    throw new Fetch402PaymentError(
+      "402: payInvoice failed; look up paymentHash before retrying to avoid double payment",
+      { invoice, paid: false, pendingPayment, cause },
+    );
+  }
+
+  const credentials = buildCredentials(pendingPayment, invResp.preimage);
+  headers.set(credentials.header, credentials.value);
+
+  let response: Response;
+  try {
+    response = await fetch(url, fetchArgs);
+  } catch (cause) {
+    // The invoice is already paid — a retry MUST reuse these credentials rather
+    // than pay again.
+    throw new Fetch402PaymentError(
+      "402: request after payment failed; retry with credentials instead of paying again",
+      {
+        invoice,
+        paid: true,
+        pendingPayment,
+        preimage: invResp.preimage,
+        credentials,
+        cause,
+      },
+    );
+  }
+
+  return attachPayment(response, {
+    paid: true,
+    amount,
+    feesPaid: invResp.fees_paid,
+    preimage: invResp.preimage,
+    credentials,
+  });
 };
 
 export function createGuardedWallet(

--- a/src/402/x402/x402.test.ts
+++ b/src/402/x402/x402.test.ts
@@ -1,5 +1,7 @@
 import fetchMock from "jest-fetch-mock";
 import { fetchWithX402 } from "./x402";
+import { Fetch402PaymentError } from "../utils";
+import { Invoice } from "../../bolt11";
 
 const INVOICE =
   "lnbc4020n1p5m6028dq80q6rqvsnp4qt5w34u6kntf5lc50jj27rvs89sgrpcpj7s6vfts042gkhxx2j6swpp5g6tquvmswkv5xf0ru7ju2qvdrf83l2ewha3qzzt0a7vurs5q30rssp54kt5hfzjngjersx8fgt60feuu8e7vnat67f3ksr98twdj7z0m0ls9qyysgqcqzp2xqyz5vqrzjqdc22wfv6lyplagj37n9dmndkrzdz8rh3lxkewvvk6arkjpefats2rf47yqqwysqqcqqqqlgqqqqqqgqfqrzjq26922n6s5n5undqrf78rjjhgpcczafws45tx8237y7pzx3fg8ww8apyqqqqqqqqjyqqqqlgqqqqr4gq2q3z5pu33awfm98ac3ysdhy046xmen4zqval67tccu35x9mxgvl6w3wmq6y03ae7pme6qr20mp5gvuqntnu8yy7nlf6gyt9zshanj2zhgqe4xde3";
@@ -282,9 +284,14 @@ describe("fetchWithX402", () => {
       headers: { "PAYMENT-REQUIRED": makePaymentRequiredHeader() },
     });
 
-    await expect(fetchWithX402(X402_URL, {}, { wallet })).rejects.toThrow(
-      "payment failed",
-    );
+    const error = await fetchWithX402(X402_URL, {}, { wallet }).catch((e) => e);
+    expect(error).toBeInstanceOf(Fetch402PaymentError);
+    expect(error.paid).toBe(false);
+    expect(error.invoice).toBe(INVOICE);
+    expect(error.paymentHash).toBe(new Invoice({ pr: INVOICE }).paymentHash);
+    expect(error.preimage).toBeUndefined();
+    expect(error.credentials).toBeUndefined();
+    expect((error.cause as Error).message).toBe("payment failed");
   });
 
   test("sets cache to no-store and mode to cors", async () => {

--- a/src/402/x402/x402.ts
+++ b/src/402/x402/x402.ts
@@ -1,9 +1,8 @@
 import {
-  applyCredentials,
-  attachPayment,
   Fetch402Options,
   PaidResponse,
-  reusedCredentialPayment,
+  payAndFetch,
+  tryReusePayment,
   Wallet,
 } from "../utils";
 import { buildX402PaymentSignature, X402Requirements } from "./utils";
@@ -80,22 +79,23 @@ export const handleX402Payment = async (
     );
   }
 
-  const invResp = await wallet.payInvoice({ invoice: invoice.paymentRequest });
-
-  const value = buildX402PaymentSignature(
-    requirements.scheme,
-    requirements.network,
-    invoice.paymentRequest,
-    requirements,
-  );
-  headers.set("payment-signature", value);
-  const response = await fetch(url, fetchArgs);
-  return attachPayment(response, {
-    paid: true,
+  return payAndFetch({
+    wallet,
+    invoice: invoice.paymentRequest,
+    url,
+    fetchArgs,
+    headers,
+    pendingPayment: {
+      scheme: "x402",
+      header: "payment-signature",
+      value: buildX402PaymentSignature(
+        requirements.scheme,
+        requirements.network,
+        invoice.paymentRequest,
+        requirements,
+      ),
+    },
     amount: invoice.satoshi,
-    feesPaid: invResp.fees_paid,
-    preimage: invResp.preimage,
-    credentials: { header: "payment-signature", value },
   });
 };
 
@@ -113,17 +113,13 @@ export const fetchWithX402 = async (
   const headers = new Headers(fetchArgs.headers ?? undefined);
   fetchArgs.headers = headers;
 
-  // If the caller supplied a credential, we MUST use it and never pay again —
-  // even if the server still responds with a 402. Re-paying here is the exact
-  // double-charge this API exists to prevent; the caller decides what to do
-  // with a rejected credential (retry after settlement, top up, etc.).
-  if (options.credentials) {
-    applyCredentials(headers, options.credentials);
-    const reusedResp = await fetch(url, fetchArgs);
-    return attachPayment(
-      reusedResp,
-      reusedCredentialPayment(options.credentials),
-    );
+  // If the caller supplied a credential or a resume token, we MUST use it and
+  // never pay again — even if the server still responds with a 402. Re-paying
+  // here is the exact double-charge this API exists to prevent; the caller
+  // decides what to do next (retry after settlement, top up, etc.).
+  const reused = await tryReusePayment(url, fetchArgs, headers, options);
+  if (reused) {
+    return reused;
   }
 
   const initResp = await fetch(url, fetchArgs);


### PR DESCRIPTION
This enables an agent to recover without repaying in two cases:

1. Payment succeeds but temporary fetch error
2. Payment times out and later succeeds (or payment succeeds but user does not get an NWC response due to temporary fetch error)

Currently BOTH of these scenarios result in the caller not receiving credentials.

See https://github.com/getAlby/cli/issues/55

This adds enables the agent to resolve most common payment issues and fetch the resource without having to re-pay, at the cost of some extra complexity.

After https://github.com/getAlby/js-lightning-tools/pull/332 is merged this PR needs to be updated (amount and fee renaming)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured payment failure errors with invoice, payment status, hash, and recovery details.
  * Added safe recovery and resume flows for interrupted payments without duplicate charges.
  * Added credential reuse across supported payment protocols.
  * Added guidance and examples for reconciling payments and resuming failed requests.

* **Bug Fixes**
  * Preserved payment credentials and recovery information when follow-up requests fail.
  * Standardized payment failure handling across L402, MPP, and x402.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->